### PR TITLE
fix: pass original model name to litellm for OpenRouter cost tracking

### DIFF
--- a/src/pr_af/cost_tracker.py
+++ b/src/pr_af/cost_tracker.py
@@ -68,10 +68,20 @@ class CostTracker(CustomLogger):
         Called synchronously right after acompletion/completion returns,
         so cost is available immediately without waiting for async callbacks.
         """
+        # OpenRouter strips the "openrouter/" prefix from response.model,
+        # so litellm can't identify the provider for pricing.  We pass
+        # model_hint (the original kwarg with prefix) to completion_cost().
+        cost = 0.0
         try:
-            cost = litellm.completion_cost(completion_response=response_obj)
+            cost = litellm.completion_cost(
+                completion_response=response_obj, model=model_hint
+            )
         except Exception:
-            return
+            # Fallback: try without model override (works for non-OpenRouter)
+            try:
+                cost = litellm.completion_cost(completion_response=response_obj)
+            except Exception:
+                return
         if not cost or cost <= 0:
             return
         model = getattr(response_obj, "model", None) or model_hint


### PR DESCRIPTION
## Summary
- OpenRouter strips the `openrouter/` prefix from `response.model`, so `litellm.completion_cost()` can't identify the provider and silently returns $0
- Pass `model_hint` (the original kwarg with prefix) to `completion_cost()` with a fallback for non-OpenRouter providers
- Discovered during live testing: Gemini 2.0 Flash Lite and Gemini 2.5 Flash both showed $0 cost despite successful completions

## Test plan
- [ ] Deploy and run a review with an OpenRouter model — verify `cost_by_model` and `global_litellm_cost` are non-zero
- [ ] Verify non-OpenRouter models still track cost correctly via the fallback path

🤖 Generated with [Claude Code](https://claude.com/claude-code)