### PR TITLE
fix: reduce concurrency and add staggered task execution

### DIFF
--- a/src/pr_af/config.py
+++ b/src/pr_af/config.py
@@ -45,8 +45,13 @@ class BudgetConfig(BaseModel):
         }
     )
 
-    # Concurrency
-    max_concurrent_reviewers: int = 8
+    # Concurrency — kept low to avoid cascading rate-limit backoff
+    # when using OpenRouter or other rate-limited providers.
+    max_concurrent_reviewers: int = 3
+
+    # Stagger delay (seconds) between launching parallel tasks to avoid
+    # burst rate-limit hits.  Set to 0 to disable staggering.
+    stagger_delay_seconds: float = 2.0
 
     # Inner loop caps (per-reviewer)
     max_reference_follows_per_reviewer: int = 3

--- a/src/pr_af/orchestrator.py
+++ b/src/pr_af/orchestrator.py
@@ -72,6 +72,29 @@ def _unwrap(result: object) -> dict:
     return cast("dict", result)
 
 
+async def _staggered_gather(
+    coros: list[Any],
+    delay: float = 2.0,
+    return_exceptions: bool = False,
+) -> list[Any]:
+    """Launch coroutines with a stagger delay between each to avoid burst
+    rate-limit hits on providers like OpenRouter.
+
+    Behaves like ``asyncio.gather()`` but introduces a small delay between
+    scheduling each coroutine as a task so that the first requests can
+    complete (or at least start) before the next ones hit the API.
+    """
+    if delay <= 0 or len(coros) <= 1:
+        return list(await asyncio.gather(*coros, return_exceptions=return_exceptions))
+
+    tasks: list[asyncio.Task[Any]] = []
+    for i, coro in enumerate(coros):
+        tasks.append(asyncio.create_task(coro))
+        if i < len(coros) - 1:
+            await asyncio.sleep(delay)
+    return list(await asyncio.gather(*tasks, return_exceptions=return_exceptions))
+
+
 class ReviewOrchestrator:
     """Orchestrates the 7-phase PR review pipeline.
 
@@ -290,7 +313,8 @@ class ReviewOrchestrator:
             return MetaDimensionResult.model_validate(result_raw)
 
         tasks = [run_lens(lens) for lens in lenses if lens in lens_map]
-        meta_results: list[MetaDimensionResult] = await asyncio.gather(*tasks)
+        stagger = self.config.budget.stagger_delay_seconds
+        meta_results: list[MetaDimensionResult] = await _staggered_gather(tasks, delay=stagger)
         self.meta_selector_results = meta_results
         self.effective_depth = self._escalate_depth(review_depth)
 
@@ -473,7 +497,10 @@ class ReviewOrchestrator:
             self._register_cost("adversary", self._extract_cost(adversary_raw))
             return self._extract_adversary_results(adversary_raw)
 
-        batch_results = await asyncio.gather(*[run_batch(b) for b in batches])
+        stagger = self.config.budget.stagger_delay_seconds
+        batch_results = await _staggered_gather(
+            [run_batch(b) for b in batches], delay=stagger,
+        )
 
         all_results: list[AdversaryResult] = []
         for batch_result in batch_results:
@@ -524,12 +551,13 @@ class ReviewOrchestrator:
                         flush=True,
                     )
                     sub_tasks = [run_dimension(sub_dim, depth + 1) for sub_dim in sub_reviews]
-                    await asyncio.gather(*sub_tasks)
+                    await _staggered_gather(sub_tasks, delay=stagger)
 
+        stagger = self.config.budget.stagger_delay_seconds
         try:
             tasks = [run_dimension(dim, current_depth) for dim in plan.dimensions]
             if tasks:
-                await asyncio.gather(*tasks)
+                await _staggered_gather(tasks, delay=stagger)
         finally:
             await findings_queue.put(None)
 
@@ -1147,7 +1175,10 @@ class ReviewOrchestrator:
             )
             compound_tasks.append(task)
 
-        results = await asyncio.gather(*compound_tasks, return_exceptions=True)
+        stagger = self.config.budget.stagger_delay_seconds
+        results = await _staggered_gather(
+            compound_tasks, delay=stagger, return_exceptions=True,
+        )
         compound_findings: list[ReviewFinding] = []
         for raw_result in results:
             if isinstance(raw_result, Exception):

--- a/tests/test_staggered_gather.py
+++ b/tests/test_staggered_gather.py
@@ -1,0 +1,96 @@
+"""Tests for _staggered_gather and related concurrency config."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from pr_af.config import BudgetConfig
+from pr_af.orchestrator import _staggered_gather
+
+
+@pytest.mark.asyncio
+async def test_staggered_gather_returns_all_results():
+    """All coroutine results are collected in order."""
+
+    async def make(i: int) -> int:
+        return i
+
+    results = await _staggered_gather([make(i) for i in range(5)], delay=0.01)
+    assert results == [0, 1, 2, 3, 4]
+
+
+@pytest.mark.asyncio
+async def test_staggered_gather_introduces_delay():
+    """Tasks are launched with measurable spacing."""
+    launch_times: list[float] = []
+
+    async def record() -> None:
+        launch_times.append(time.monotonic())
+
+    await _staggered_gather([record() for _ in range(3)], delay=0.05)
+
+    assert len(launch_times) == 3
+    # Second task should start at least 40ms after the first (allowing jitter)
+    assert launch_times[1] - launch_times[0] >= 0.04
+    assert launch_times[2] - launch_times[1] >= 0.04
+
+
+@pytest.mark.asyncio
+async def test_staggered_gather_zero_delay_is_immediate():
+    """When delay=0 it behaves like asyncio.gather."""
+
+    async def make(i: int) -> int:
+        return i
+
+    results = await _staggered_gather([make(i) for i in range(3)], delay=0)
+    assert results == [0, 1, 2]
+
+
+@pytest.mark.asyncio
+async def test_staggered_gather_single_coro():
+    """Single coroutine works without delay."""
+
+    async def make() -> str:
+        return "ok"
+
+    results = await _staggered_gather([make()], delay=1.0)
+    assert results == ["ok"]
+
+
+@pytest.mark.asyncio
+async def test_staggered_gather_return_exceptions():
+    """Exceptions are captured when return_exceptions=True."""
+
+    async def ok() -> str:
+        return "ok"
+
+    async def fail() -> str:
+        raise ValueError("boom")
+
+    results = await _staggered_gather(
+        [ok(), fail(), ok()], delay=0.01, return_exceptions=True,
+    )
+    assert results[0] == "ok"
+    assert isinstance(results[1], ValueError)
+    assert results[2] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_staggered_gather_propagates_exception():
+    """Without return_exceptions, first exception propagates."""
+
+    async def fail() -> str:
+        raise ValueError("boom")
+
+    with pytest.raises(ValueError, match="boom"):
+        await _staggered_gather([fail()], delay=0.01)
+
+
+def test_budget_config_defaults():
+    """Verify the updated concurrency and stagger defaults."""
+    config = BudgetConfig()
+    assert config.max_concurrent_reviewers == 3
+    assert config.stagger_delay_seconds == 2.0


### PR DESCRIPTION
## Summary
- Reduce `max_concurrent_reviewers` from 8 to 3 to match OpenCode's subprocess limit and avoid burst rate-limit hits
- Add configurable `stagger_delay_seconds` (default 2.0s) to space parallel task launches
- Add `_staggered_gather()` utility that behaves like `asyncio.gather()` but introduces delay between task scheduling
- Applied to all 5 parallel execution points: meta-selectors, review dimensions, sub-reviews, adversary batches, compound analysis

### Companion PR
- AgentField SDK rate limiter tuning: Agent-Field/agentfield#265 (or equivalent)

### Expected Impact
Combined with the AgentField SDK rate limiter tuning, estimated workflow runtime for 30-40 node MiniMax workflows drops from ~2.5 hours to ~15-30 minutes.

## Test plan
- [x] 7 new tests for `_staggered_gather` (delay behavior, edge cases, exception handling)
- [x] Config default assertions (`max_concurrent_reviewers=3`, `stagger_delay_seconds=2.0`)
- [x] All existing tests pass with no regressions
- [ ] Deploy and verify workflow runtime reduction on OpenRouter+MiniMax workloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)