### PR TITLE
chore: pin agentfield >=0.1.55 for rate limiter fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 requires-python = ">=3.11"
 authors = [{ name = "AgentField", email = "hello@agentfield.dev" }]
 dependencies = [
-    "agentfield>=0.1.53",
+    "agentfield>=0.1.55",
     "pydantic>=2.0",
     "httpx>=0.27",
     "pyyaml>=6.0",


### PR DESCRIPTION
## Summary
- Pin agentfield dependency to >=0.1.55 to pick up the fail-fast rate limiter defaults
- Companion to PR #9 (staggered execution) which is already merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)