### PR TITLE
fix: post-review memory and disk cleanup

### DIFF
--- a/src/pr_af/app.py
+++ b/src/pr_af/app.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 # pyright: reportMissingImports=false
+import contextlib
+import gc
 import hashlib
 import hmac
 import json
 import os
+import shutil
 import subprocess
 from pathlib import Path
 from typing import Any, cast
@@ -76,7 +79,12 @@ def _checkout_pr_branch(target_dir: str, pr_number: int) -> None:
     )
 
 
-def _resolve_repo(repo_path: str | None, pr_url: str | None) -> str:
+def _resolve_repo(repo_path: str | None, pr_url: str | None) -> tuple[str, bool]:
+    """Resolve the repository path, cloning if necessary.
+
+    Returns (repo_path, was_cloned) — ``was_cloned`` is True when we created a
+    fresh clone under the workdir so the caller knows it's safe to delete later.
+    """
     workdir = os.getenv("PR_AF_WORKDIR", "/workspaces")
     target = repo_path
     pr_number: int | None = None
@@ -88,7 +96,7 @@ def _resolve_repo(repo_path: str | None, pr_url: str | None) -> str:
         pr_number = _extract_pr_number(pr_url)
 
     if isinstance(target, str) and os.path.isdir(target):
-        return str(Path(target).resolve())
+        return str(Path(target).resolve()), False
 
     if isinstance(target, str) and target.startswith(("https://", "http://", "git@")):
         repo_name = target.rstrip("/").split("/")[-1].replace(".git", "")
@@ -138,9 +146,9 @@ def _resolve_repo(repo_path: str | None, pr_url: str | None) -> str:
         if pr_number:
             _checkout_pr_branch(target_dir, pr_number)
 
-        return target_dir
+        return target_dir, True
 
-    return str(Path(os.getenv("PR_AF_REPO_PATH", os.getcwd())).resolve())
+    return str(Path(os.getenv("PR_AF_REPO_PATH", os.getcwd())).resolve()), False
 
 
 @app.reasoner()
@@ -194,7 +202,7 @@ async def review(
         suggestion_mode=suggestion_mode,
         no_budget=no_budget,
     )
-    resolved_repo_path = _resolve_repo(review_input.repo_path, review_input.pr_url)
+    resolved_repo_path, was_cloned = _resolve_repo(review_input.repo_path, review_input.pr_url)
     if not review_input.repo_path:
         review_input = review_input.model_copy(update={"repo_path": resolved_repo_path})
     config = ReviewConfig.from_input(review_input)
@@ -209,6 +217,20 @@ async def review(
         print(f"[PR-AF] Pipeline error: {exc}\n{_tb.format_exc()}", flush=True)
         cast("Any", app).note(f"Review pipeline failed: {exc}", tags=["review", "error"])
         raise HTTPException(status_code=500, detail={"error": f"review execution failed: {exc}"}) from exc
+    finally:
+        # --- Post-review cleanup: free memory and disk -----------------------
+        # 1. Drop heavy orchestrator references so GC can reclaim them
+        orchestrator.cleanup()
+        del orchestrator
+
+        # 2. Remove cloned repo from disk (only repos we cloned, not user-provided)
+        if was_cloned and resolved_repo_path:
+            with contextlib.suppress(OSError):
+                shutil.rmtree(resolved_repo_path)
+                print(f"[PR-AF] Cleaned up cloned repo: {resolved_repo_path}", flush=True)
+
+        # 3. Force a full GC pass to release fragmented arenas back to the OS
+        gc.collect()
 
     return result.model_dump()
 

--- a/src/pr_af/orchestrator.py
+++ b/src/pr_af/orchestrator.py
@@ -820,6 +820,22 @@ class ReviewOrchestrator:
 
         return current_depth
 
+    def cleanup(self) -> None:
+        """Release all heavy in-memory state after a review completes (or fails).
+
+        Called from the request handler's ``finally`` block so memory is reclaimed
+        even when the pipeline errors out mid-execution.
+        """
+        self._cleanup_context_dir()
+
+        # Drop large data structures so the GC can free them immediately
+        self.pr_data = None
+        self.intake_result = None
+        self.anatomy_result = None
+        self.meta_selector_results.clear()
+        self.cost_breakdown.clear()
+        self._cost_tracker.reset()
+
     def _cleanup_context_dir(self) -> None:
         repo_path = self.input.repo_path or ""
         if not repo_path:


### PR DESCRIPTION
## Summary
- Cloned repos were never deleted from `/workspaces/` after reviews completed, accumulating disk usage across reviews
- The `ReviewOrchestrator` held all findings, evidence, PR data, and anatomy results in memory indefinitely — Python's arena allocator never released these back to the OS
- Over multiple reviews this caused container memory to climb to **15GB+** and never come back down (confirmed via Railway SSH — fresh deploy sits at 175MB)

## Changes
- `_resolve_repo()` returns `(path, was_cloned)` tuple so we only delete repos we cloned, not user-provided paths
- `finally` block in `review()` ensures cleanup runs even when the pipeline errors mid-execution
- New `ReviewOrchestrator.cleanup()` method nulls all heavy instance data (pr_data, intake/anatomy results, meta-selector results, cost tracker)
- `shutil.rmtree()` removes cloned repo from disk after each review
- `gc.collect()` forces CPython to release fragmented memory arenas back to the OS

## Test plan
- [ ] Deploy to Railway, trigger 2-3 PR reviews, verify memory returns to baseline (~175-200MB) after each review
- [ ] Verify logs show `[PR-AF] Cleaned up cloned repo: /workspaces/...` after each review
- [ ] Trigger a review that fails mid-pipeline, verify cleanup still runs (check logs)
- [ ] Test with `repo_path` pointing to a local directory — verify it is NOT deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)