### PR TITLE
fix: add claude-code runtime to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,8 @@ RUN pip install --no-cache-dir --prefix=/install \
     "python-dotenv>=1.0" \
     "fastapi>=0.100" \
     "uvicorn>=0.20" \
-    "PyJWT[crypto]>=2.8" && \
+    "PyJWT[crypto]>=2.8" \
+    "claude-agent-sdk>=0.1" && \
     pip install --no-cache-dir --prefix=/install --no-deps .
 
 
@@ -35,7 +36,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     PORT=8004 \
     HOME=/home/praf \
     PYTHONPATH=/app/src \
-    PATH=/home/praf/.opencode/bin:${PATH} \
+    PATH=/home/praf/.opencode/bin:/usr/local/share/npm-global/bin:${PATH} \
     XDG_DATA_HOME=/home/praf/.local/share \
     PR_AF_WORKDIR=/workspaces
 
@@ -44,11 +45,14 @@ WORKDIR /app
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
-    git && \
+    git \
+    nodejs \
+    npm && \
+    npm install -g @anthropic-ai/claude-code --prefix /usr/local/share/npm-global && \
     groupadd --gid 10001 praf && \
     useradd --uid 10001 --gid praf --create-home --home-dir /home/praf --shell /bin/sh praf && \
     su -s /bin/sh praf -c "curl -fsSL https://opencode.ai/install | bash" && \
-    mkdir -p /workspaces /home/praf/.local/share /home/praf/.opencode/data && \
+    mkdir -p /workspaces /home/praf/.local/share /home/praf/.opencode/data /home/praf/.claude && \
     chown -R praf:praf /app /workspaces /home/praf && \
     rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,10 +50,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     npm && \
     npm install -g @anthropic-ai/claude-code --prefix /usr/local/share/npm-global && \
     groupadd --gid 10001 praf && \
-    useradd --uid 10001 --gid praf --create-home --home-dir /home/praf --shell /bin/sh praf && \
-    su -s /bin/sh praf -c "curl -fsSL https://opencode.ai/install | bash" && \
+    useradd --uid 10001 --gid praf --no-create-home --home-dir /home/praf --shell /bin/sh praf && \
     mkdir -p /workspaces /home/praf/.local/share /home/praf/.opencode/data /home/praf/.claude && \
-    chown -R praf:praf /app /workspaces /home/praf && \
+    chown -R praf:praf /home/praf /app /workspaces && \
+    su -s /bin/sh praf -c "curl -fsSL https://opencode.ai/install | bash" && \
     rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /home/praf/.config/opencode && \


### PR DESCRIPTION
## Summary
- Installs Node.js + `@anthropic-ai/claude-code` CLI in the Docker runtime stage so the `claude-code` harness provider works in Railway
- Adds `claude-agent-sdk` Python package to the builder pip install (thin wrapper that spawns the CLI)
- Creates `~/.claude/` directory for the praf user
- Adds the npm-global bin to PATH so the `claude` binary is discoverable

## Root cause
The `claude-agent-sdk` Python SDK works by spawning the `claude` CLI binary as a subprocess (`SubprocessCLITransport`). The Docker image had none of the required runtime: no Node.js, no CLI binary, no Python SDK. Executions with `provider=claude-code` would fail immediately or hang indefinitely.

The CLI authenticates via `ANTHROPIC_API_KEY` env var (already configured in Railway) — no credential files needed.

## Test plan
- [ ] Deploy to Railway and run a PR review with `provider=claude-code`
- [ ] Verify `claude` binary is on PATH inside the container
- [ ] Confirm auth works via `ANTHROPIC_API_KEY` without credential files

🤖 Generated with [Claude Code](https://claude.com/claude-code)