### PR TITLE
feat: per-request provider override for harness selection

### DIFF
--- a/src/pr_af/app.py
+++ b/src/pr_af/app.py
@@ -175,6 +175,7 @@ async def review(
     focus: str = "auto",
     ignore_paths: list[str] | None = None,
     hints: list[str] | None = None,
+    provider: str | None = None,
     models: dict[str, str] | None = None,
     max_concurrent_reviewers: int | None = None,
     max_coverage_iterations: int | None = None,
@@ -185,10 +186,12 @@ async def review(
     suggestion_mode: str = "comment",
     no_budget: bool = False,
 ) -> dict[str, object]:
+    effective_provider = provider or _ai_config.provider
     print(
         f"[PR-AF DEBUG] review() called with pr_url={pr_url!r}, "
         f"diff_text={'<set>' if diff_text else None}, repo_path={repo_path!r}, "
-        f"depth={depth!r}, dry_run={dry_run!r}, no_budget={no_budget!r}",
+        f"depth={depth!r}, dry_run={dry_run!r}, no_budget={no_budget!r}, "
+        f"provider={provider!r} (effective={effective_provider!r})",
         flush=True,
     )
     review_input = ReviewInput(
@@ -203,6 +206,7 @@ async def review(
         focus=focus,
         ignore_paths=ignore_paths or [],
         hints=hints or [],
+        provider=provider,
         models=models,
         max_concurrent_reviewers=max_concurrent_reviewers,
         max_coverage_iterations=max_coverage_iterations,
@@ -216,7 +220,7 @@ async def review(
     resolved_repo_path, was_cloned = _resolve_repo(review_input.repo_path, review_input.pr_url)
     if not review_input.repo_path:
         review_input = review_input.model_copy(update={"repo_path": resolved_repo_path})
-    config = ReviewConfig.from_input(review_input, provider=_ai_config.provider)
+    config = ReviewConfig.from_input(review_input, provider=effective_provider)
     orchestrator = ReviewOrchestrator(app=app, input=review_input, config=config)
     try:
         result = await orchestrator.run()

--- a/src/pr_af/config.py
+++ b/src/pr_af/config.py
@@ -229,6 +229,10 @@ class ReviewConfig(BaseModel):
     scoring: ScoringConfig = Field(default_factory=ScoringConfig)
     comments: CommentConfig = Field(default_factory=CommentConfig)
 
+    # Effective provider for this review ("opencode", "claude-code", etc.).
+    # Set by from_input(); harness calls use this for per-call provider override.
+    provider: str = "opencode"
+
     # File ignore patterns (glob)
     ignore_paths: list[str] = Field(
         default_factory=lambda: [
@@ -294,6 +298,9 @@ class ReviewConfig(BaseModel):
 
         if hasattr(review_input, "suggestion_mode") and review_input.suggestion_mode:
             config.comments.suggestion_mode = review_input.suggestion_mode
+
+        # Store the effective provider so downstream harness calls can override.
+        config.provider = provider
 
         # Resolve tier names ('budget', 'mid', 'premium') → actual model IDs
         config.models = config.models.resolve(provider=provider)

--- a/src/pr_af/orchestrator.py
+++ b/src/pr_af/orchestrator.py
@@ -243,6 +243,7 @@ class ReviewOrchestrator:
             depth=self.input.depth,
             gate_model=self.config.models.intake_gate,
             fallback_model=self.config.models.intake_fallback,
+            provider=self.config.provider,
         )
         self.agent_invocations += 1
         self._register_cost("intake", self._extract_cost(result_raw))
@@ -260,6 +261,7 @@ class ReviewOrchestrator:
             intake=intake.model_dump(),
             repo_path=self.input.repo_path or "",
             model=self.config.models.anatomy_semantic,
+            provider=self.config.provider,
         )
         self.agent_invocations += 1
         self._register_cost("anatomy", self._extract_cost(result_raw))
@@ -276,6 +278,7 @@ class ReviewOrchestrator:
             depth=review_depth,
             hints=self.config.hints,
             model=self.config.models.planner,
+            provider=self.config.provider,
         )
         self.agent_invocations += 1
         self._register_cost("planning", self._extract_cost(result_raw))
@@ -307,6 +310,7 @@ class ReviewOrchestrator:
                 repo_path=self.input.repo_path or "",
                 diff_patches=self._build_file_patches(),
                 model=self.config.models.reviewer,
+                provider=self.config.provider,
             )
             self.agent_invocations += 1
             self._register_cost("meta_selectors", self._extract_cost(result_raw))
@@ -395,6 +399,7 @@ class ReviewOrchestrator:
             pr_context=self._build_pr_context_string(),
             repo_path=self.input.repo_path or "",
             model=self.config.models.reviewer,
+            provider=self.config.provider,
         )
         self.agent_invocations += 1
         self._register_cost("adversary", self._extract_cost(verifier_raw))
@@ -492,6 +497,7 @@ class ReviewOrchestrator:
                 repo_path=self.input.repo_path or "",
                 evidence_packages=batch_evidence if batch_evidence else None,
                 model=self.config.models.adversary,
+                provider=self.config.provider,
             )
             self.agent_invocations += 1
             self._register_cost("adversary", self._extract_cost(adversary_raw))
@@ -537,6 +543,7 @@ class ReviewOrchestrator:
                     diff_patches=dim_patches if dim_patches else None,
                     all_dimension_names=[d.name for d in plan.dimensions if d.id != dim.id],
                     model=self.config.models.reviewer,
+                    provider=self.config.provider,
                 )
                 self.agent_invocations += 1
                 self._register_cost("review", self._extract_cost(result_raw))
@@ -660,6 +667,7 @@ class ReviewOrchestrator:
                 reviewed_clusters=reviewed_clusters,
                 dimension_names_reviewed=dimension_names,
                 model=self.config.models.coverage_gate,
+                provider=self.config.provider,
             )
             self.agent_invocations += 1
             self._register_cost("coverage", self._extract_cost(gate_raw))
@@ -1143,6 +1151,7 @@ class ReviewOrchestrator:
             compound_findings=[f.model_dump() for f in compound_findings],
             individual_findings_summary=individual_summary,
             model=self.config.models.dedup_gate,
+            provider=self.config.provider,
         )
         self.agent_invocations += 1
         self._register_cost("cross_ref", self._extract_cost(dedup_raw))
@@ -1188,6 +1197,7 @@ class ReviewOrchestrator:
                 repo_path=self.input.repo_path or "",
                 evidence_map=cluster_evidence or None,
                 model=self.config.models.cross_ref,
+                provider=self.config.provider,
             )
             compound_tasks.append(task)
 

--- a/src/pr_af/reasoners/harnesses.py
+++ b/src/pr_af/reasoners/harnesses.py
@@ -249,7 +249,10 @@ def _cluster_descriptions(clusters: list[ChangeCluster]) -> list[dict[str, objec
 
 
 @router.reasoner()
-async def intake_phase(pr_data: dict, depth: str = "standard", gate_model: str = "", fallback_model: str = "", provider: str = "") -> dict:
+async def intake_phase(
+    pr_data: dict, depth: str = "standard", gate_model: str = "",
+    fallback_model: str = "", provider: str = "",
+) -> dict:
     pr = GitHubPRData.model_validate(pr_data)
     files_changed = len(pr.changed_files)
     languages = _extract_languages(pr)

--- a/src/pr_af/reasoners/harnesses.py
+++ b/src/pr_af/reasoners/harnesses.py
@@ -249,7 +249,7 @@ def _cluster_descriptions(clusters: list[ChangeCluster]) -> list[dict[str, objec
 
 
 @router.reasoner()
-async def intake_phase(pr_data: dict, depth: str = "standard", gate_model: str = "", fallback_model: str = "") -> dict:
+async def intake_phase(pr_data: dict, depth: str = "standard", gate_model: str = "", fallback_model: str = "", provider: str = "") -> dict:
     pr = GitHubPRData.model_validate(pr_data)
     files_changed = len(pr.changed_files)
     languages = _extract_languages(pr)
@@ -315,12 +315,13 @@ async def intake_phase(pr_data: dict, depth: str = "standard", gate_model: str =
         f"actual substance of the change (not just the PR title restated).\n\n{fallback_input}",
         schema=IntakeResult,
         model=fallback_model or None,
+        provider=provider or None,
     )
     return _with_cost(fallback_result.parsed.model_dump(), fallback_result) if fallback_result.parsed else {}
 
 
 @router.reasoner()
-async def anatomy_phase(pr_data: dict, intake: dict, repo_path: str = "", model: str = "") -> dict:
+async def anatomy_phase(pr_data: dict, intake: dict, repo_path: str = "", model: str = "", provider: str = "") -> dict:
     import json as _json
 
     pr = GitHubPRData.model_validate(pr_data)
@@ -378,6 +379,7 @@ async def anatomy_phase(pr_data: dict, intake: dict, repo_path: str = "", model:
         schema=_AnatomySemanticResult,
         cwd=repo_path or None,
         model=model or None,
+        provider=provider or None,
     )
 
     parsed = semantic.parsed if semantic.parsed else _AnatomySemanticResult()
@@ -399,7 +401,7 @@ async def anatomy_phase(pr_data: dict, intake: dict, repo_path: str = "", model:
 @router.reasoner()
 async def planning_phase(
     intake: dict, anatomy: dict, depth: str = "standard",
-    hints: list[str] | None = None, model: str = "",
+    hints: list[str] | None = None, model: str = "", provider: str = "",
 ) -> dict:
     import json as _json
 
@@ -485,6 +487,7 @@ async def planning_phase(
         f"{context}",
         schema=ReviewPlan,
         model=model or None,
+        provider=provider or None,
     )
     if plan_result.parsed:
         return _with_cost(plan_result.parsed.model_dump(), plan_result)
@@ -542,6 +545,7 @@ async def meta_semantic(
     repo_path: str = "",
     diff_patches: dict[str, str] | None = None,
     model: str = "",
+    provider: str = "",
 ) -> dict:
     """Semantic lens: What does this code DO differently?
 
@@ -612,6 +616,7 @@ async def meta_semantic(
         schema=MetaDimensionResult,
         cwd=repo_path or None,
         model=model or None,
+        provider=provider or None,
     )
     parsed = result.parsed if result.parsed else MetaDimensionResult(lens="semantic", dimensions=[])
     parsed.lens = "semantic"
@@ -626,6 +631,7 @@ async def meta_mechanical(
     repo_path: str = "",
     diff_patches: dict[str, str] | None = None,
     model: str = "",
+    provider: str = "",
 ) -> dict:
     """Mechanical lens: Does this code WORK correctly at the language level?
 
@@ -702,6 +708,7 @@ async def meta_mechanical(
         schema=MetaDimensionResult,
         cwd=repo_path or None,
         model=model or None,
+        provider=provider or None,
     )
     parsed = result.parsed if result.parsed else MetaDimensionResult(lens="mechanical", dimensions=[])
     parsed.lens = "mechanical"
@@ -716,6 +723,7 @@ async def meta_systemic(
     repo_path: str = "",
     diff_patches: dict[str, str] | None = None,
     model: str = "",
+    provider: str = "",
 ) -> dict:
     """Systemic lens: How does this code FIT the codebase?
 
@@ -792,6 +800,7 @@ async def meta_systemic(
         schema=MetaDimensionResult,
         cwd=repo_path or None,
         model=model or None,
+        provider=provider or None,
     )
     parsed = result.parsed if result.parsed else MetaDimensionResult(lens="systemic", dimensions=[])
     parsed.lens = "systemic"
@@ -812,6 +821,7 @@ async def review_dimension(
     diff_patches: dict[str, str] | None = None,
     all_dimension_names: list[str] | None = None,
     model: str = "",
+    provider: str = "",
 ) -> dict:
     ctx_files = context_files or []
     risks = risk_surfaces or []
@@ -967,6 +977,7 @@ async def review_dimension(
         schema=_ReviewFindingsResult,
         cwd=repo_path or None,
         model=model or None,
+        provider=provider or None,
     )
     parsed = result.parsed if result.parsed else _ReviewFindingsResult()
     sub_review_dicts = []
@@ -995,6 +1006,7 @@ async def compound_finder_phase(
     repo_path: str = "",
     evidence_map: dict[str, dict] | None = None,
     model: str = "",
+    provider: str = "",
 ) -> dict:
     import json as _json
 
@@ -1073,6 +1085,7 @@ async def compound_finder_phase(
         schema=_CompoundResult,
         cwd=repo_path or None,
         model=model or None,
+        provider=provider or None,
     )
     parsed = result.parsed if result.parsed else _CompoundResult()
     return _with_cost({"findings": [finding.model_dump() for finding in parsed.findings]}, result)
@@ -1083,6 +1096,7 @@ async def compound_dedup_phase(
     compound_findings: list[dict],
     individual_findings_summary: str = "",
     model: str = "",
+    provider: str = "",
 ) -> dict:
     """Deduplicate compound findings via a single harness call.
 
@@ -1141,6 +1155,7 @@ async def compound_dedup_phase(
         "Include your reasoning.",
         schema=_CompoundDedupResult,
         model=model or None,
+        provider=provider or None,
     )
     parsed = result.parsed if result.parsed else _CompoundDedupResult()
 
@@ -1160,6 +1175,7 @@ async def evidence_verifier(
     pr_context: str = "",
     repo_path: str = "",
     model: str = "",
+    provider: str = "",
 ) -> dict:
     import json as _json
 
@@ -1256,6 +1272,7 @@ async def evidence_verifier(
         schema=_VerificationResult,
         cwd=repo_path or None,
         model=model or None,
+        provider=provider or None,
     )
     parsed = result.parsed if result.parsed else _VerificationResult()
     return _with_cost({"verified_findings": [vf.model_dump() for vf in parsed.verified_findings]}, result)
@@ -1269,6 +1286,7 @@ async def adversary_phase(
     repo_path: str = "",
     evidence_packages: dict[str, dict] | None = None,
     model: str = "",
+    provider: str = "",
 ) -> dict:
     import json as _json
 
@@ -1385,6 +1403,7 @@ async def adversary_phase(
         schema=_AdversaryPhaseResult,
         cwd=repo_path or None,
         model=model or None,
+        provider=provider or None,
     )
     parsed = result.parsed if result.parsed else _AdversaryPhaseResult()
     return _with_cost({"results": [item.model_dump() for item in parsed.results]}, result)
@@ -1396,6 +1415,7 @@ async def coverage_gate(
     reviewed_clusters: list[str],
     dimension_names_reviewed: list[str] | None = None,
     model: str = "",
+    provider: str = "",  # unused — coverage_gate uses .ai(), not .harness()
 ) -> dict:
     import json as _json
 

--- a/src/pr_af/schemas/input.py
+++ b/src/pr_af/schemas/input.py
@@ -30,6 +30,11 @@ class ReviewInput(BaseModel):
     ignore_paths: list[str] = Field(default_factory=list)
     hints: list[str] = Field(default_factory=list)  # Project-specific review hints
 
+    # Provider override (per-call).  Selects the coding-agent harness:
+    # "opencode", "claude-code", "codex", "gemini".
+    # When None, falls back to the PR_AF_PROVIDER env var (server default).
+    provider: str | None = None
+
     # Model overrides (per-call API variable)
     # Keys match ModelConfig field names: intake_gate, planner, reviewer, etc.
     # Values are model identifiers (e.g. "anthropic/claude-sonnet-4", "openai/gpt-4o")


### PR DESCRIPTION
## Summary
- Adds an optional `provider` parameter to the review API endpoint, allowing callers to select the coding-agent harness (`opencode`, `claude-code`, `codex`, `gemini`) per-request without redeploying
- The `PR_AF_PROVIDER` env var remains the default when no provider is specified — fully backward-compatible
- Threads the provider from `ReviewInput` → `ReviewConfig` → orchestrator → all 11 `.harness()` calls, leveraging agentfield's existing per-call `provider` override

## Motivation
Currently switching between harnesses (e.g., opencode with gemini-flash vs claude-code with opus) requires changing env vars and redeploying. This makes benchmarking across providers and ad-hoc model testing unnecessarily expensive in ops time.

## Changes
| File | What changed |
|------|-------------|
| `schemas/input.py` | Added `provider: str \| None` field to `ReviewInput` |
| `app.py` | Added `provider` param to `review()`, computes `effective_provider` falling back to env default |
| `config.py` | Added `provider` field to `ReviewConfig`, stored in `from_input()` |
| `orchestrator.py` | Passes `self.config.provider` to all 10 harness function call sites |
| `reasoners/harnesses.py` | Added `provider: str = ""` param to all 12 harness functions, passes `provider=provider or None` to each `.harness()` call |

## Test plan
- [ ] Deploy and send a review request **without** `provider` — should use env default (backward compat)
- [ ] Send a request with `provider: "opencode"` and `models` containing OpenRouter model IDs
- [ ] Send a request with `provider: "claude-code"` and `models` using tier names (budget/mid/premium)
- [ ] Verify `.ai()` calls (intake_gate, coverage_gate) are unaffected by provider override

🤖 Generated with [Claude Code](https://claude.com/claude-code)