### PR TITLE
feat(budget): env-driven defaults for review reasoner caps

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,15 @@ GH_TOKEN=
 
 # Working directory for cloned repos (optional)
 # PR_AF_WORKDIR=/workspaces
+
+# Budget defaults for the `review` reasoner (optional).
+# Callers (e.g. github-buddy) intentionally don't thread these as kwargs, so
+# tuning lives here on the deployment side.
+#   - PR_AF_NO_BUDGET=true disables all cost/duration enforcement (recommended
+#     for production deployments where review quality matters more than cost).
+#   - PR_AF_MAX_DURATION_SECONDS lifts the wall-clock cap (default 300s is far
+#     below a real review's 35–50min runtime; bump to 1800+ if not disabling).
+#   - PR_AF_MAX_COST_USD raises the global cost cap (default $2).
+# PR_AF_NO_BUDGET=false
+# PR_AF_MAX_DURATION_SECONDS=300
+# PR_AF_MAX_COST_USD=2.0

--- a/src/pr_af/app.py
+++ b/src/pr_af/app.py
@@ -159,6 +159,43 @@ if _ai_config.provider == "claude-code":
 NODE_ID = os.getenv("PR_AF", "pr-af")
 HarnessConfig = _agentfield.HarnessConfig
 
+
+def _env_bool(key: str, default: bool) -> bool:
+    val = os.getenv(key)
+    if val is None:
+        return default
+    return val.strip().lower() in ("1", "true", "yes", "on")
+
+
+def _env_float(key: str, default: float) -> float:
+    val = os.getenv(key)
+    if val is None:
+        return default
+    try:
+        return float(val)
+    except ValueError:
+        return default
+
+
+def _env_int(key: str, default: int) -> int:
+    val = os.getenv(key)
+    if val is None:
+        return default
+    try:
+        return int(val)
+    except ValueError:
+        return default
+
+
+# Budget defaults for the `review` reasoner. Hard-coded fallbacks preserve
+# prior behavior; env vars let a deployment lift caps (or disable budgets
+# entirely with PR_AF_NO_BUDGET=true) without code changes. github-buddy
+# does NOT thread budget overrides through `app.call`, so these env vars
+# are the only way to retune budgets in production.
+_DEFAULT_MAX_COST_USD = _env_float("PR_AF_MAX_COST_USD", 2.0)
+_DEFAULT_MAX_DURATION_SECONDS = _env_int("PR_AF_MAX_DURATION_SECONDS", 300)
+_DEFAULT_NO_BUDGET = _env_bool("PR_AF_NO_BUDGET", False)
+
 app = Agent(
     node_id=NODE_ID,
     version="0.1.0",
@@ -289,8 +326,8 @@ async def review(
     base_ref: str | None = None,
     head_ref: str | None = None,
     depth: str = "auto",
-    max_cost_usd: float = 2.0,
-    max_duration_seconds: int = 300,
+    max_cost_usd: float = _DEFAULT_MAX_COST_USD,
+    max_duration_seconds: int = _DEFAULT_MAX_DURATION_SECONDS,
     focus: str = "auto",
     ignore_paths: list[str] | None = None,
     hints: list[str] | None = None,
@@ -303,7 +340,7 @@ async def review(
     dry_run: bool = False,
     post_pr_number: int | None = None,
     suggestion_mode: str = "comment",
-    no_budget: bool = False,
+    no_budget: bool = _DEFAULT_NO_BUDGET,
 ) -> dict[str, object]:
     effective_provider = provider or _ai_config.provider
     print(


### PR DESCRIPTION
## Summary

The `review` reasoner had hard-coded `max_duration_seconds=300` (5 min) and `max_cost_usd=2.0` defaults. On the Railway test deployment, this fires `BudgetExhaustedError("Budget exhausted before meta-selectors")` ~6 minutes into every real PR review — the docs themselves say a 500-line PR takes 35–50 min, so 300s never had a chance.

Upstream callers (e.g. github-buddy) intentionally don't thread budget overrides through `app.call("pr-af.review", ...)` (its CLAUDE.md explicitly forbids it), so deployments currently have no way to lift the caps without editing this repo's source.

This PR makes the three budget defaults read from env at module load:

- `PR_AF_NO_BUDGET` (bool, default `false`) — when `true`, disables all cost/duration enforcement.
- `PR_AF_MAX_DURATION_SECONDS` (int, default `300`) — wall-clock cap.
- `PR_AF_MAX_COST_USD` (float, default `2.0`) — global cost cap.

Hard-coded fallbacks preserve current behavior for callers that don't set the env. The `BudgetConfig.no_budget` short-circuit in `_budget_or_timeout_exhausted` already exists — this just lets a deployment flip it.

## How this resolves the Railway hang

A real review on the deployment now needs `PR_AF_NO_BUDGET=true` (recommended) or `PR_AF_MAX_DURATION_SECONDS=1800` set on the pr-af service env. Combined with the underlying error-propagation fix in agentfield (separate PR), the 9+ hour "running" UI state goes away.

## Test plan

- [ ] `python3 -m py_compile src/pr_af/app.py` (done locally — passes).
- [ ] Run a review with `PR_AF_NO_BUDGET=true` set in the deployment env and confirm meta-selectors complete.
- [ ] Run a review *without* the env set and confirm the prior 300s/$2 behavior is unchanged (i.e. `BudgetExhaustedError` still fires for callers depending on it).
- [ ] Smoke: `app.call("pr-af.review", pr_url=..., max_duration_seconds=600)` still wins over the env default (kwargs always override).

🤖 Generated with [Claude Code](https://claude.com/claude-code)