### PR TITLE
fix(config): respect PR_AF_MODEL across all tiers; default to kimi-k2.5

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,9 +5,12 @@ OPENROUTER_API_KEY=
 GH_TOKEN=
 
 # Model configuration (optional — defaults shown)
-# PR_AF_MODEL=minimax/minimax-m2.5
-# PR_AF_AI_MODEL=minimax/minimax-m2.5
+# PR_AF_MODEL=openrouter/moonshotai/kimi-k2.5
+# PR_AF_AI_MODEL=openrouter/moonshotai/kimi-k2.5
 # PR_AF_PROVIDER=opencode
+#
+# PR_AF_MODEL applies to all tiers (budget/mid/premium) unless individually
+# overridden via PR_AF_MODEL_BUDGET / PR_AF_MODEL_MID / PR_AF_MODEL_PREMIUM.
 
 # AgentField control plane (optional — for hosted deployments)
 # AGENTFIELD_SERVER=http://localhost:8080

--- a/src/pr_af/config.py
+++ b/src/pr_af/config.py
@@ -82,10 +82,10 @@ def _default_tier_map(provider: str = "opencode") -> dict[str, str]:
     # opencode / default — OpenRouter model IDs
     ai_model = os.getenv(
         "PR_AF_AI_MODEL",
-        os.getenv("AI_MODEL", os.getenv("PR_AF_MODEL", "openrouter/google/gemini-2.5-flash")),
+        os.getenv("AI_MODEL", os.getenv("PR_AF_MODEL", "openrouter/moonshotai/kimi-k2.5")),
     )
     return {
-        "budget": os.getenv("PR_AF_MODEL_BUDGET", "openrouter/google/gemini-2.5-flash"),
+        "budget": os.getenv("PR_AF_MODEL_BUDGET", ai_model),
         "mid": os.getenv("PR_AF_MODEL_MID", ai_model),
         "premium": os.getenv("PR_AF_MODEL_PREMIUM", ai_model),
     }
@@ -329,12 +329,12 @@ class AIIntegrationConfig(BaseModel):
         default_factory=lambda: os.getenv("PR_AF_PROVIDER", os.getenv("HARNESS_PROVIDER", "opencode"))
     )
     harness_model: str = Field(
-        default_factory=lambda: os.getenv("PR_AF_MODEL", os.getenv("HARNESS_MODEL", "minimax/minimax-m2.5"))
+        default_factory=lambda: os.getenv("PR_AF_MODEL", os.getenv("HARNESS_MODEL", "openrouter/moonshotai/kimi-k2.5"))
     )
     ai_model: str = Field(
         default_factory=lambda: os.getenv(
             "PR_AF_AI_MODEL",
-            os.getenv("AI_MODEL", os.getenv("PR_AF_MODEL", "minimax/minimax-m2.5")),
+            os.getenv("AI_MODEL", os.getenv("PR_AF_MODEL", "openrouter/moonshotai/kimi-k2.5")),
         )
     )
     max_turns: int = Field(default_factory=lambda: int(os.getenv("PR_AF_MAX_TURNS", "50")))


### PR DESCRIPTION
## Summary

Fixes a silent override where setting `PR_AF_MODEL` did not propagate to the `budget` tier (intake_gate / coverage_gate / dedup_gate), and cleans up stale defaults that pointed at minimax / gemini.

### The leak (real silent override of user intent)

In `_default_tier_map("opencode")`, `mid` and `premium` tiers correctly fell back to `ai_model` (which honors `PR_AF_MODEL` → `AI_MODEL` → `PR_AF_AI_MODEL`), but `budget` was hardcoded to `openrouter/google/gemini-2.5-flash`. Setting `PR_AF_MODEL=openrouter/moonshotai/kimi-k2.5` left the budget-tier gates running on gemini with no warning. Now `budget` falls back to `ai_model` like the other tiers, so a single `PR_AF_MODEL` env var actually applies everywhere.

`PR_AF_MODEL_BUDGET` still works for callers who want to keep gates cheap.

### Default cleanup

- `AIIntegrationConfig.harness_model`: `minimax/minimax-m2.5` → `openrouter/moonshotai/kimi-k2.5`
- `AIIntegrationConfig.ai_model`: `minimax/minimax-m2.5` → `openrouter/moonshotai/kimi-k2.5`
- `_default_tier_map` ai_model fallback: `openrouter/google/gemini-2.5-flash` → `openrouter/moonshotai/kimi-k2.5`
- `.env.example`: updated documented examples + added a note that `PR_AF_MODEL` covers all tiers unless overridden per-tier.

### Out of scope

- The `claude-code` provider tier map (`haiku` / `sonnet` / `opus`) is left as-is — those identifiers are required by the Claude Agent SDK, not a configurable preference.
- All `router.app.harness(..., model=model or None)` and `router.app.ai(..., model=...)` call sites already thread the user's model through correctly; no changes needed there.

## Test plan

- [ ] With no env vars set, confirm `AIIntegrationConfig().harness_model == "openrouter/moonshotai/kimi-k2.5"`
- [ ] With `PR_AF_MODEL=openrouter/moonshotai/kimi-k2.5`, confirm `_default_tier_map()` returns kimi for budget/mid/premium
- [ ] With `PR_AF_MODEL_BUDGET=openrouter/google/gemini-2.5-flash` and `PR_AF_MODEL=openrouter/moonshotai/kimi-k2.5`, confirm budget=gemini and mid/premium=kimi (per-tier override still wins)
- [ ] Run a real PR review on Railway and confirm Kimi shows up in logs across intake/coverage gates (previously gemini)

🤖 Generated with [Claude Code](https://claude.com/claude-code)