### PR TITLE
perf(review): bump max_concurrent_reviewers 3 → 10 to unblock review_dimension fan-out

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,3 +34,9 @@ GH_TOKEN=
 # PR_AF_NO_BUDGET=false
 # PR_AF_MAX_DURATION_SECONDS=300
 # PR_AF_MAX_COST_USD=2.0
+
+# Concurrency for review_dimension fan-out. Default 10 lets all 6–8
+# dimensions run in parallel; raise/lower based on your provider's
+# per-key rate limits. Was 3 before — caused 3× wall-clock multiplier
+# in production.
+# PR_AF_MAX_CONCURRENT_REVIEWERS=10

--- a/src/pr_af/config.py
+++ b/src/pr_af/config.py
@@ -45,9 +45,17 @@ class BudgetConfig(BaseModel):
         }
     )
 
-    # Concurrency — kept low to avoid cascading rate-limit backoff
-    # when using OpenRouter or other rate-limited providers.
-    max_concurrent_reviewers: int = 3
+    # Concurrency for review_dimension fan-out.
+    #
+    # Production data showed 8 review_dimensions throttled by this semaphore at
+    # the previous default of 3, turning per-dimension cost (~25 min) into a
+    # 3× wall-clock multiplier (≥75 min for the review phase alone). Bumped to
+    # 10 — well within OpenRouter's per-key rate limits on Kimi K2.5 and the
+    # other models we run through opencode. Override via PR_AF_MAX_CONCURRENT_REVIEWERS
+    # if a deployment needs to dial it back for a stricter rate-limit ceiling.
+    max_concurrent_reviewers: int = Field(
+        default_factory=lambda: int(os.getenv("PR_AF_MAX_CONCURRENT_REVIEWERS", "10"))
+    )
 
     # Stagger delay (seconds) between launching parallel tasks to avoid
     # burst rate-limit hits.  Set to 0 to disable staggering.

--- a/tests/test_staggered_gather.py
+++ b/tests/test_staggered_gather.py
@@ -90,7 +90,21 @@ async def test_staggered_gather_propagates_exception():
 
 
 def test_budget_config_defaults():
-    """Verify the updated concurrency and stagger defaults."""
-    config = BudgetConfig()
-    assert config.max_concurrent_reviewers == 3
-    assert config.stagger_delay_seconds == 2.0
+    """Verify the updated concurrency and stagger defaults.
+
+    Concurrency was raised from 3 → 10 after production data showed 8
+    review_dimensions throttled by the old semaphore, turning ~25-min
+    per-dimension cost into a 3× wall-clock multiplier. The default is
+    overridable via PR_AF_MAX_CONCURRENT_REVIEWERS — clear that env var
+    so the test pins the in-code default rather than the runtime override.
+    """
+    import os
+
+    prior = os.environ.pop("PR_AF_MAX_CONCURRENT_REVIEWERS", None)
+    try:
+        config = BudgetConfig()
+        assert config.max_concurrent_reviewers == 10
+        assert config.stagger_delay_seconds == 2.0
+    finally:
+        if prior is not None:
+            os.environ["PR_AF_MAX_CONCURRENT_REVIEWERS"] = prior


### PR DESCRIPTION
## Why

Production data on a recent review run showed 8 `review_dimension` phases each taking ~25 min of LLM work but throttled by `max_concurrent_reviewers = 3`. Wall-clock time on the review phase was ~3× per-dimension cost — ≥75 min, with several dimensions blocked behind the semaphore doing nothing. This was the dominant reason `pr-af.review` runs were hitting the 7200s `agent_call_timeout` in github-buddy and burning the parent reasoner.

Per-dimension LLM time is what it is until the meta-selectors get refactored. But we were leaving free wall-clock time on the table by serializing dimensions that can already run in parallel.

## What

1. Default raised **3 → 10**. Typical reviews have 6–8 dimensions; at 10 they all run in parallel and the phase is bounded by the slowest single dimension.
2. New env override `PR_AF_MAX_CONCURRENT_REVIEWERS` so a deployment can dial it back if its provider has tighter limits.
3. `stagger_delay_seconds = 2.0` is unchanged — the 2-second stagger remains first-line defense against burst rate-limit hits, the semaphore is just no longer the bottleneck.

The original comment cited "OpenRouter or other rate-limited providers" as the reason for the cap. At 10 concurrent on Kimi K2.5 we're well within OpenRouter's per-key limits; if a deployment runs against a slower-rate provider it can lower via env without a code change.

## Expected impact

Worst case observed today: review phase 75–100 min wall, total run 110+ min, hitting the 7200s caller timeout.

After this change: review phase ≈ slowest single dimension (~25–40 min), total run ~50–80 min. Should stop hitting the timeout on normal-sized PRs.

This is the highest-leverage single-line speedup. Not the last one — `meta_semantic` / `meta_mechanical` / `meta_systemic` are each one monolithic 14–38 min LLM call and would benefit from a separate fast-proposal + parallel-validation refactor. That's a bigger change and lands later.

## Test plan

- [x] `test_budget_config_defaults` updated to pin the new default and clear `PR_AF_MAX_CONCURRENT_REVIEWERS` so it asserts the in-code default rather than the runtime override
- [x] Full pr-af test suite green (one pre-existing `test_cost_tracker` failure on `main`, unrelated to this PR)
- [ ] After merge: trigger a real review on a multi-file PR via github-buddy and confirm review_dimension phases run all-at-once with no semaphore queuing

🤖 Generated with [Claude Code](https://claude.com/claude-code)