### PR TITLE
chore(deps): bump agentfield floor to >=0.1.77

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 requires-python = ">=3.11"
 authors = [{ name = "AgentField", email = "hello@agentfield.dev" }]
 dependencies = [
-    "agentfield>=0.1.55",
+    "agentfield>=0.1.77",
     "pydantic>=2.0",
     "httpx>=0.27",
     "pyyaml>=6.0",


### PR DESCRIPTION
## Summary
- Bumps the `agentfield` floor in `pyproject.toml` from `>=0.1.55` to `>=0.1.77` to pick up the cooperative cancellation feature shipped in agentfield#542.
- Without this floor, pr-af still serves reviews on Railway but doesn't honor cancel-tree — a stuck pr-af run can be marked cancelled in the control plane, but the in-flight phase (intake / anatomy / dimension generation / reviewer parallel calls) keeps running and burns LLM spend until natural completion.

## Test plan
- [x] `pip install -e .` resolves to agentfield 0.1.77 or later.
- [ ] Deploy to Railway, kick off a 500-line PR review, hit cancel-tree from the control-plane UI mid-anatomy, confirm pr-af short-circuits within seconds (CancelledError surfaces in the awaited Anthropic / OpenRouter call) rather than completing all phases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)