### PR TITLE
docs: document opencode web-search opt-in for review reasoners

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,16 @@ GH_TOKEN=
 # GITHUB_WEBHOOK_SECRET=
 # PR_AF_BOT_MENTION=@pr-af
 
+# Web search (optional — enables opencode's built-in websearch / webfetch
+# tools so review reasoners can verify external API contracts, look up
+# CVEs / deprecation status, and check library version compatibility).
+#
+# Both vars must be set. They reach the opencode subprocess via the
+# parent-env propagation in agentfield's run_cli — no PR-AF wiring needed
+# beyond setting them on the deployment. Get a key at https://exa.ai/.
+# OPENCODE_ENABLE_EXA=1
+# EXA_API_KEY=
+
 # Working directory for cloned repos (optional)
 # PR_AF_WORKDIR=/workspaces
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,17 @@ Poll for results:
 curl http://localhost:8080/api/v1/executions/<execution_id>
 ```
 
+### Optional: web search
+
+Review reasoners can look up external context — verify API contracts, check CVE/deprecation status, confirm library version behavior — by enabling opencode's built-in `websearch` and `webfetch` tools. Two env vars on the deployment:
+
+```
+OPENCODE_ENABLE_EXA=1
+EXA_API_KEY=...
+```
+
+When set, the model decides per-task whether the lookup is worth the latency. No PR-AF wiring is needed; the env vars propagate naturally into the opencode subprocess through agentfield's CLI harness. Get a key at [exa.ai](https://exa.ai/).
+
 ## GitHub Actions Integration
 
 The easiest way to use PR-AF is to drop it into your GitHub Actions. It requires **zero configuration** and runs securely using GitHub's built-in `GITHUB_TOKEN`.


### PR DESCRIPTION
## Summary

Documents the two-env-var knob that enables opencode's built-in `websearch` / `webfetch` tools for PR-AF's review reasoners:

```
OPENCODE_ENABLE_EXA=1
EXA_API_KEY=...
```

When both vars are set on the deployment, the model gains the ability to verify external API contracts, check CVE/deprecation status, and confirm library version behavior during a review — and decides per-task whether the lookup is worth doing.

## Why no code changes

opencode reads these env vars natively. They reach the opencode subprocess through agentfield's `run_cli` parent-env propagation (regression-guarded in [Agent-Field/agentfield#544](https://github.com/Agent-Field/agentfield/pull/544)). The model is told about the available tools via the standard tool-definition layer — verified end-to-end against the agentfield SDK, where the model autonomously invoked `websearch` for a task that needed current information.

So the wiring already works; this PR just makes the knob discoverable.

## What's changed

- `.env.example` — adds the two env vars with a brief explanation
- `README.md` — adds an "Optional: web search" subsection under Quick Start

## Why no prompt-level guardrails

Review reasoners are short / single-shot / analytic — no long iterative loops where an unrestrained model could rabbit-hole on searches. The model's own judgment plus opencode's tool advertisement is sufficient. (SWE-AF's `run_coder` is the exception and gets a restraint snippet in its own PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)