### PR TITLE
chore(deps): bump baked-in default model from Kimi K2.5 to K2.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,8 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     AGENTFIELD_SERVER=http://agentfield:8080 \
     HARNESS_PROVIDER=opencode \
-    HARNESS_MODEL=openrouter/moonshotai/kimi-k2.5 \
-    AI_MODEL=openrouter/moonshotai/kimi-k2.5 \
+    HARNESS_MODEL=openrouter/moonshotai/kimi-k2.6 \
+    AI_MODEL=openrouter/moonshotai/kimi-k2.6 \
     PORT=8004 \
     HOME=/home/praf \
     PYTHONPATH=/app/src \
@@ -59,7 +59,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /home/praf/.config/opencode && \
-    echo '{"$schema":"https://opencode.ai/config.json","model":"openrouter/moonshotai/kimi-k2.5","small_model":"openrouter/moonshotai/kimi-k2.5","provider":{"openrouter":{"options":{"apiKey":"{env:OPENROUTER_API_KEY}"},"models":{"moonshotai/kimi-k2.5":{}}}}}' \
+    echo '{"$schema":"https://opencode.ai/config.json","model":"openrouter/moonshotai/kimi-k2.6","small_model":"openrouter/moonshotai/kimi-k2.6","provider":{"openrouter":{"options":{"apiKey":"{env:OPENROUTER_API_KEY}"},"models":{"moonshotai/kimi-k2.6":{}}}}}' \
     > /home/praf/.config/opencode/opencode.json && \
     chown -R praf:praf /home/praf/.config
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,8 +23,8 @@ services:
       - AGENTFIELD_API_KEY=${AGENTFIELD_API_KEY:-}
       - AGENT_CALLBACK_URL=http://pr-af:8004
       - HARNESS_PROVIDER=opencode
-      - HARNESS_MODEL=${HARNESS_MODEL:-openrouter/moonshotai/kimi-k2.5}
-      - AI_MODEL=${AI_MODEL:-openrouter/moonshotai/kimi-k2.5}
+      - HARNESS_MODEL=${HARNESS_MODEL:-openrouter/moonshotai/kimi-k2.6}
+      - AI_MODEL=${AI_MODEL:-openrouter/moonshotai/kimi-k2.6}
       - OPENROUTER_API_KEY=${OPENROUTER_API_KEY}
       - GITHUB_TOKEN=${GITHUB_TOKEN:-}
       - GH_TOKEN=${GH_TOKEN:-}

--- a/src/pr_af/config.py
+++ b/src/pr_af/config.py
@@ -50,7 +50,7 @@ class BudgetConfig(BaseModel):
     # Production data showed 8 review_dimensions throttled by this semaphore at
     # the previous default of 3, turning per-dimension cost (~25 min) into a
     # 3× wall-clock multiplier (≥75 min for the review phase alone). Bumped to
-    # 10 — well within OpenRouter's per-key rate limits on Kimi K2.5 and the
+    # 10 — well within OpenRouter's per-key rate limits on Kimi K2.6 and the
     # other models we run through opencode. Override via PR_AF_MAX_CONCURRENT_REVIEWERS
     # if a deployment needs to dial it back for a stricter rate-limit ceiling.
     max_concurrent_reviewers: int = Field(


### PR DESCRIPTION
## Summary

Brings the baked-in defaults in line with what production actually runs on. Three places still pointed at `openrouter/moonshotai/kimi-k2.5`:

- `Dockerfile` — `HARNESS_MODEL` and `AI_MODEL` ENV defaults, plus the inline `~/.config/opencode/opencode.json` (both `model` and `small_model`).
- `docker-compose.yml` — `HARNESS_MODEL` and `AI_MODEL` defaults for local dev.
- `src/pr_af/config.py` — one stale comment line referring to "Kimi K2.5".

Railway has env-var overrides set to k2.6 so production was unaffected, but a fresh deploy with no env overrides — or any local `docker compose up` — would land on k2.5, drifting away from what the rest of the stack uses.

## Test plan

- [ ] `docker compose config` parses
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)