### PR TITLE
fix(opencode): respect HARNESS_MODEL in baked-in opencode.json (small_model path)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /home/praf/.config/opencode && \
-    echo '{"$schema":"https://opencode.ai/config.json","model":"openrouter/moonshotai/kimi-k2.5","small_model":"openrouter/moonshotai/kimi-k2.5","provider":{"openrouter":{"options":{"apiKey":"{env:OPENROUTER_API_KEY}"},"models":{"moonshotai/kimi-k2.5":{}}}}}' \
+    echo '{"$schema":"https://opencode.ai/config.json","model":"{env:HARNESS_MODEL}","small_model":"{env:HARNESS_MODEL}","provider":{"openrouter":{"options":{"apiKey":"{env:OPENROUTER_API_KEY}"}}}}' \
     > /home/praf/.config/opencode/opencode.json && \
     chown -R praf:praf /home/praf/.config
 


### PR DESCRIPTION
## Summary

The baked-in \`~/.config/opencode/opencode.json\` hardcoded both \`model\` and \`small_model\` to a literal \`openrouter/moonshotai/kimi-k2.5\`. The main model is fine — the Python harness provider passes \`-m \$HARNESS_MODEL\` to \`opencode run\`, which overrides config. But OpenCode's \`small_model\` (used for session titles, summarization, prompt compaction) reads from config, not the CLI flag. Result: a deployer setting \`HARNESS_MODEL=X\` on Railway gets X for the main model and \`kimi-k2.5\` for small_model — env var silently bypassed.

OpenCode supports \`{env:VAR}\` interpolation in string fields. This PR switches \`model\` and \`small_model\` to \`{env:HARNESS_MODEL}\` so both paths read from the same env var the rest of the pr-af stack already respects.

## What changes

\`\`\`diff
- "model":"openrouter/moonshotai/kimi-k2.5",
- "small_model":"openrouter/moonshotai/kimi-k2.5",
- "provider":{"openrouter":{"options":{"apiKey":"{env:OPENROUTER_API_KEY}"},"models":{"moonshotai/kimi-k2.5":{}}}}
+ "model":"{env:HARNESS_MODEL}",
+ "small_model":"{env:HARNESS_MODEL}",
+ "provider":{"openrouter":{"options":{"apiKey":"{env:OPENROUTER_API_KEY}"}}}
\`\`\`

The Dockerfile already sets \`HARNESS_MODEL=openrouter/moonshotai/kimi-k2.5\` as the image default, so a fresh container with no env overrides still has a value to interpolate. Railway / docker-compose env injection wins because it lands after the image's ENV layer.

The \`models\` registration block was dropped — OpenCode auto-handles unknown model names from a configured provider, and pinning a specific name there broke the moment \`HARNESS_MODEL\` changed.

## Why this isn't the same as #23 (closed)

#23 was bumping the literal \`kimi-k2.5\` → \`kimi-k2.6\` in the same files. That was cosmetic — env vars already overrode the main-model path. *This* PR fixes the actual env-var bypass: the small_model field that env vars couldn't override at all.

## Test plan

- [ ] \`docker build .\` succeeds
- [ ] On staging deploy with \`HARNESS_MODEL\` set, verify OpenRouter dashboard shows zero traffic to non-\$HARNESS_MODEL models from this service's key

🤖 Generated with [Claude Code](https://claude.com/claude-code)