### PR TITLE
chore(deps): bump agentfield floor to 0.1.79

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY pyproject.toml README.md ./
 COPY src/ src/
 
 RUN pip install --no-cache-dir --prefix=/install \
-    "agentfield" \
+    "agentfield>=0.1.79" \
     "pydantic>=2.0" \
     "httpx>=0.27" \
     "python-dotenv>=1.0" \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 requires-python = ">=3.11"
 authors = [{ name = "AgentField", email = "hello@agentfield.dev" }]
 dependencies = [
-    "agentfield>=0.1.77",
+    "agentfield>=0.1.79",
     "pydantic>=2.0",
     "httpx>=0.27",
     "pyyaml>=6.0",


### PR DESCRIPTION
## Summary

Bumps the `agentfield` SDK floor from `>=0.1.77` to `>=0.1.79` in `pyproject.toml`, and tightens the unconstrained `"agentfield"` install in the Dockerfile to `"agentfield>=0.1.79"`.

## Why

0.1.79 contains the pause-aware reasoner-timeout fix (Agent-Field/agentfield#552). PR-AF doesn't currently call `app.pause()` itself, but bumping the floor here keeps the SDK consistent with SWE-AF (where the bug surfaces) and unblocks any future use of `pause` / `wait_for_resume`.

## Why bumping the constraint string is required

Docker layer caching keys off the `pip install` instruction's exact string. The Dockerfile previously installed agentfield with no version constraint at all (just `"agentfield"`), so the cached layer kept the version it last resolved even after newer SDK releases. Pinning the floor to `>=0.1.79` busts that layer and prevents silent drift on rebuilds.

## Test plan

- [ ] CI green
- [ ] After merge, redeploy on Railway and confirm a fresh image was built (not cache-restored)
- [ ] Confirm `agentfield` resolves to 0.1.79+ in the running container (`pip show agentfield`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)