### PR TITLE
chore(deps): bump agentfield floor to 0.1.80

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY pyproject.toml README.md ./
 COPY src/ src/
 
 RUN pip install --no-cache-dir --prefix=/install \
-    "agentfield>=0.1.79" \
+    "agentfield>=0.1.80" \
     "pydantic>=2.0" \
     "httpx>=0.27" \
     "python-dotenv>=1.0" \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 requires-python = ">=3.11"
 authors = [{ name = "AgentField", email = "hello@agentfield.dev" }]
 dependencies = [
-    "agentfield>=0.1.79",
+    "agentfield>=0.1.80",
     "pydantic>=2.0",
     "httpx>=0.27",
     "pyyaml>=6.0",


### PR DESCRIPTION
## Summary

Bumps the agentfield SDK floor from 0.1.79 to 0.1.80 in both pyproject.toml and the Dockerfile's bare ``pip install "agentfield>=…"`` line.

0.1.80 ships cross-reasoner pause-clock propagation (Agent-Field/agentfield#555). The constraint string itself has to change for Docker's pip layer cache to re-resolve — leaving the floor at 0.1.79 means the cached layer keeps shipping 0.1.79 even after PyPI has 0.1.80.

## Test plan
- [ ] CI green
- [ ] Container build confirms ``agentfield-0.1.80`` is what gets installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)