### PR TITLE
chore(deps): bump agentfield floor to 0.1.81

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY pyproject.toml README.md ./
 COPY src/ src/
 
 RUN pip install --no-cache-dir --prefix=/install \
-    "agentfield>=0.1.80" \
+    "agentfield>=0.1.81" \
     "pydantic>=2.0" \
     "httpx>=0.27" \
     "python-dotenv>=1.0" \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 requires-python = ">=3.11"
 authors = [{ name = "AgentField", email = "hello@agentfield.dev" }]
 dependencies = [
-    "agentfield>=0.1.80",
+    "agentfield>=0.1.81",
     "pydantic>=2.0",
     "httpx>=0.27",
     "pyyaml>=6.0",


### PR DESCRIPTION
## Summary
- Bump agentfield constraint from \`>=0.1.80\` to \`>=0.1.81\` in pyproject.toml and Dockerfile.
- Picks up the poll-driven cross-reasoner pause propagation fix from Agent-Field/agentfield#562.

## Why
v0.1.80 attempted the same fix via an SSE event listener gated behind \`enable_event_stream\` (default off). It never fired in production. v0.1.81 moves the pause toggle into \`wait_for_result\`'s polling loop, which runs unconditionally.

## Test plan
- [ ] CI green
- [ ] After deploy, run a \`pr-af.review\` flow that hits a hax-sdk approval gate; the parent watchdog should not trip the wallclock budget if active work is under it

🤖 Generated with [Claude Code](https://claude.com/claude-code)