### PR TITLE
chore(deps): bump agentfield floor to 0.1.83

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY pyproject.toml README.md ./
 COPY src/ src/
 
 RUN pip install --no-cache-dir --prefix=/install \
-    "agentfield>=0.1.82" \
+    "agentfield>=0.1.83" \
     "pydantic>=2.0" \
     "httpx>=0.27" \
     "python-dotenv>=1.0" \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 requires-python = ">=3.11"
 authors = [{ name = "AgentField", email = "hello@agentfield.dev" }]
 dependencies = [
-    "agentfield>=0.1.82",
+    "agentfield>=0.1.83",
     "pydantic>=2.0",
     "httpx>=0.27",
     "pyyaml>=6.0",


### PR DESCRIPTION
## Summary

Bumps the agentfield SDK floor from `>=0.1.82` to `>=0.1.83` in both `pyproject.toml` and `Dockerfile`. Picks up the cancellation-skips-sync-fallback fix shipped in [agentfield#566](https://github.com/Agent-Field/agentfield/pull/566): a cancelled awaited child no longer triggers a silent sync-fallback re-execution.

Both files bumped because the Dockerfile installs agentfield directly — leaving the Dockerfile pin at 0.1.82 would keep restoring the cached `pip install` layer and ship 0.1.82 even after 0.1.83 is on PyPI.

## Test plan

- [x] CI green (Docker build pulls 0.1.83)
- [ ] After merge, a fresh deploy logs `agentfield==0.1.83` (or newer) in the install step

🤖 Generated with [Claude Code](https://claude.com/claude-code)