### PR TITLE
chore: bump agentfield pin to >=0.1.84

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY pyproject.toml README.md ./
 COPY src/ src/
 
 RUN pip install --no-cache-dir --prefix=/install \
-    "agentfield>=0.1.83" \
+    "agentfield>=0.1.84" \
     "pydantic>=2.0" \
     "httpx>=0.27" \
     "python-dotenv>=1.0" \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 requires-python = ">=3.11"
 authors = [{ name = "AgentField", email = "hello@agentfield.dev" }]
 dependencies = [
-    "agentfield>=0.1.83",
+    "agentfield>=0.1.84",
     "pydantic>=2.0",
     "httpx>=0.27",
     "pyyaml>=6.0",


### PR DESCRIPTION
Picks up agentfield 0.1.84 ([release](https://github.com/Agent-Field/agentfield/releases/tag/v0.1.84), [merged PR](https://github.com/Agent-Field/agentfield/pull/569)).

## What's in 0.1.84
INFO-level diagnostic logging on the cross-reasoner pause-propagation hot path. No behavior change; same imports, same control flow.

## Why this PR is needed
Docker `pip install` layers are cached against file contents — `>=0.1.83` already permits 0.1.84, but unless the constraint string itself changes, the cached layer with 0.1.83 keeps getting restored on rebuild. Bumped both `pyproject.toml` AND `Dockerfile` because the Dockerfile pins separately (one alone wouldn't invalidate the cache for both build paths). Same playbook as the 0.1.82→0.1.83 round (PR #33).

## Test plan
- [ ] Merge → wait for Railway to redeploy
- [ ] `railway ssh --service pr-af "pip show agentfield"` returns 0.1.84