### PR TITLE
refactor: simplify env var surface; align on SWE-AF naming

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,9 +29,8 @@ FROM python:3.11-slim AS runtime
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     AGENTFIELD_SERVER=http://agentfield:8080 \
-    HARNESS_PROVIDER=opencode \
-    HARNESS_MODEL=openrouter/moonshotai/kimi-k2.5 \
-    AI_MODEL=openrouter/moonshotai/kimi-k2.5 \
+    PR_AF_PROVIDER=opencode \
+    PR_AF_MODEL=openrouter/moonshotai/kimi-k2.5 \
     PORT=8004 \
     HOME=/home/praf \
     PYTHONPATH=/app/src \

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ There are excellent AI code review tools on the market. PR-AF is not designed to
 
 ```bash
 git clone https://github.com/Agent-Field/pr-af.git && cd pr-af
-cp .env.example .env          # Add OPENROUTER_API_KEY, GITHUB_TOKEN
+cp .env.example .env          # Add OPENROUTER_API_KEY, GH_TOKEN
 docker compose up --build
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,11 +22,9 @@ services:
       - AGENTFIELD_SERVER=http://agentfield:8080
       - AGENTFIELD_API_KEY=${AGENTFIELD_API_KEY:-}
       - AGENT_CALLBACK_URL=http://pr-af:8004
-      - HARNESS_PROVIDER=opencode
-      - HARNESS_MODEL=${HARNESS_MODEL:-openrouter/moonshotai/kimi-k2.5}
-      - AI_MODEL=${AI_MODEL:-openrouter/moonshotai/kimi-k2.5}
+      - PR_AF_PROVIDER=${PR_AF_PROVIDER:-opencode}
+      - PR_AF_MODEL=${PR_AF_MODEL:-openrouter/moonshotai/kimi-k2.5}
       - OPENROUTER_API_KEY=${OPENROUTER_API_KEY}
-      - GITHUB_TOKEN=${GITHUB_TOKEN:-}
       - GH_TOKEN=${GH_TOKEN:-}
       - XDG_DATA_HOME=/home/praf/.local/share
       - PR_AF_WORKDIR=/workspaces

--- a/docs/DX.md
+++ b/docs/DX.md
@@ -33,7 +33,7 @@ POST /api/v1/execute/async/pr-af.review
 - Configurable: `--clone` (full clone), `--shallow` (depth=1), `--no-clone` (API only)
 
 **Authentication:**
-- `GITHUB_TOKEN` env var (personal access token or GitHub App installation token)
+- `GH_TOKEN` env var (personal access token or GitHub App installation token)
 - GitHub App: preferred for CI/CD (fine-grained permissions, higher rate limits)
 
 **Best for:** CI/CD pipelines, GitHub Action triggers, full-featured review.
@@ -369,7 +369,7 @@ comments:
 
 | Variable | Required | Description |
 |---|---|---|
-| `GITHUB_TOKEN` | Yes (for GitHub output) | GitHub PAT or App installation token |
+| `GH_TOKEN` | Yes (for GitHub output) | GitHub PAT or App installation token |
 | `AGENTFIELD_API_KEY` | Yes | AgentField platform API key |
 | `OPENROUTER_API_KEY` | Yes | LLM provider API key |
 | `PR_AF_CONFIG` | No | Path to config file (default: `.pr-af.yml`) |

--- a/src/pr_af/app.py
+++ b/src/pr_af/app.py
@@ -24,7 +24,7 @@ _project_root = Path(__file__).resolve().parents[2]
 load_dotenv(_project_root / ".env")
 
 _ai_config = AIIntegrationConfig.from_env()
-NODE_ID = os.getenv("PR_AF", "pr-af")
+NODE_ID = os.getenv("NODE_ID", "pr-af")
 HarnessConfig = _agentfield.HarnessConfig
 
 app = Agent(
@@ -95,7 +95,7 @@ def _resolve_repo(repo_path: str | None, pr_url: str | None) -> str:
         os.makedirs(workdir, exist_ok=True)
 
         clone_url = target
-        gh_token = os.getenv("GH_TOKEN") or os.getenv("GITHUB_TOKEN", "")
+        gh_token = os.getenv("GH_TOKEN", "")
         if gh_token and clone_url.startswith("https://github.com/"):
             clone_url = clone_url.replace("https://github.com/", f"https://{gh_token}@github.com/")
 

--- a/src/pr_af/config.py
+++ b/src/pr_af/config.py
@@ -238,17 +238,12 @@ class ReviewConfig(BaseModel):
 
 
 class AIIntegrationConfig(BaseModel):
-    provider: str = Field(
-        default_factory=lambda: os.getenv("PR_AF_PROVIDER", os.getenv("HARNESS_PROVIDER", "opencode"))
-    )
+    provider: str = Field(default_factory=lambda: os.getenv("PR_AF_PROVIDER", "opencode"))
     harness_model: str = Field(
-        default_factory=lambda: os.getenv("PR_AF_MODEL", os.getenv("HARNESS_MODEL", "minimax/minimax-m2.5"))
+        default_factory=lambda: os.getenv("PR_AF_MODEL", "minimax/minimax-m2.5")
     )
     ai_model: str = Field(
-        default_factory=lambda: os.getenv(
-            "PR_AF_AI_MODEL",
-            os.getenv("AI_MODEL", os.getenv("PR_AF_MODEL", "minimax/minimax-m2.5")),
-        )
+        default_factory=lambda: os.getenv("PR_AF_MODEL", "minimax/minimax-m2.5")
     )
     max_turns: int = Field(default_factory=lambda: int(os.getenv("PR_AF_MAX_TURNS", "50")))
     max_retries: int = Field(default_factory=lambda: int(os.getenv("PR_AF_AI_MAX_RETRIES", "3")))
@@ -257,9 +252,7 @@ class AIIntegrationConfig(BaseModel):
     )
     max_backoff_seconds: float = Field(default_factory=lambda: float(os.getenv("PR_AF_AI_MAX_BACKOFF_SECONDS", "8.0")))
     opencode_bin: str = Field(default_factory=lambda: os.getenv("PR_AF_OPENCODE_BIN", "opencode"))
-    opencode_server: str | None = Field(
-        default_factory=lambda: os.getenv("PR_AF_OPENCODE_SERVER", os.getenv("OPENCODE_SERVER"))
-    )
+    opencode_server: str | None = Field(default_factory=lambda: os.getenv("PR_AF_OPENCODE_SERVER"))
 
     @classmethod
     def from_env(cls) -> AIIntegrationConfig:
@@ -271,7 +264,6 @@ class AIIntegrationConfig(BaseModel):
             "ANTHROPIC_API_KEY",
             "OPENAI_API_KEY",
             "GOOGLE_API_KEY",
-            "GITHUB_TOKEN",
             "GH_TOKEN",
         )
         env: dict[str, str] = {key: value for key in env_keys if (value := os.getenv(key))}

--- a/src/pr_af/github/client.py
+++ b/src/pr_af/github/client.py
@@ -85,7 +85,7 @@ def _is_github_app_configured() -> bool:
 
 class GitHubClient:
     def __init__(self, token: str | None = None):
-        self.token = token or os.getenv("GITHUB_TOKEN", "")
+        self.token = token or os.getenv("GH_TOKEN", "")
         self.base_url = "https://api.github.com"
         self._use_app_auth = _is_github_app_configured()
 
@@ -262,7 +262,7 @@ class GitHubClient:
         if self._use_app_auth:
             token = await _get_installation_token(owner, repo)
         else:
-            token = os.getenv("GH_TOKEN") or self.token or os.getenv("GITHUB_TOKEN", "")
+            token = os.getenv("GH_TOKEN") or self.token
         if not token:
             raise ValueError("GitHub token is required for clone_repo")
 


### PR DESCRIPTION
## Summary

Drops five legacy env-var aliases that were side-by-side with their canonical names, and fixes a latent NODE_ID typo. Pairs with the companion PR in github-buddy that aligns its env var names on the same canonical surface.

**Aliases removed (canonical replacement in parens):**

- `HARNESS_PROVIDER` (→ `PR_AF_PROVIDER`)
- `HARNESS_MODEL` (→ `PR_AF_MODEL`)
- `AI_MODEL` and `PR_AF_AI_MODEL` (→ `PR_AF_MODEL`; per-tier overrides via `PR_AF_MODEL_BUDGET` / `_MID` / `_PREMIUM` unchanged)
- `OPENCODE_SERVER` (→ `PR_AF_OPENCODE_SERVER`)
- `GITHUB_TOKEN` (→ `GH_TOKEN`)

SWE-AF (our public release with the most users) only uses `GH_TOKEN` and `NODE_ID`, so the same naming is now consistent across all three agents (github-buddy, pr-af, SWE-AF).

**Latent bug fix:**

`src/pr_af/app.py` was reading `os.getenv("PR_AF", "pr-af")` instead of `os.getenv("NODE_ID", "pr-af")`. The `PR_AF` env var is never set anywhere, so pr-af's registered node id silently always defaulted to `"pr-af"` regardless of deployer intent — fixed.

**Why this is safe:**

These five aliases had `PR_AF_*` canonical replacements that have been side-by-side for several releases. Internal deployments and the docker-compose / Dockerfile have been updated to the new names in this PR; nothing left in the repo references the removed aliases. The GitHub Actions integration in the README still references `secrets.GITHUB_TOKEN` (GitHub Actions' built-in secret name — that's a GitHub-side convention, not our env var, and is correctly mapped to `GH_TOKEN`).

## Companion PR

Agent-Field/github-buddy#55 — same naming alignment in github-buddy + a workspace-level docker-compose that brings all three agents up together.

## Test plan

- [x] `ruff check src/` — clean
- [x] Smoke import test confirms `PR_AF_MODEL` propagates to both `harness_model` and `ai_model`, `GH_TOKEN` flows through `GitHubClient` and `provider_env`, `NODE_ID` registers correctly.
- [x] `docker compose config` — syntactically valid
- [ ] No tests in `tests/` on `origin/main`, so I couldn't run the full pytest suite against this branch directly. Against the equivalent change on the internal pr-af tree (which has the full suite), 25/25 non-cost-tracker tests pass (the one cost-tracker failure is pre-existing and unrelated).
- [ ] Set `PR_AF_MODEL` / `PR_AF_PROVIDER` / `GH_TOKEN` on the Railway service before merging — the deployed container will read the new names. Drop the now-unused legacy aliases (`HARNESS_MODEL`, `HARNESS_PROVIDER`, `AI_MODEL`, `PR_AF_AI_MODEL`, `OPENCODE_SERVER`, `GITHUB_TOKEN`) after the deploy succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)