### PR TITLE
docs: lead quickstart with `af call`, keep curl as HTTP alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ Other tools run a single LLM pass over the diff with a fixed checklist. PR-AF **
 
 ## One-Call DX
 
+Trigger it with the `af` CLI (requires af ≥ 0.1.86) — it streams live progress and prints the result:
+
+```bash
+af call pr-af.review --in '{"pr_url": "https://github.com/owner/repo/pull/123"}'
+```
+
+Prefer raw HTTP? Hit the API directly with curl:
+
 ```bash
 curl -X POST http://localhost:8080/api/v1/execute/async/pr-af.review \
   -H "Content-Type: application/json" \

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Other tools run a single LLM pass over the diff with a fixed checklist. PR-AF **
 
 ## One-Call DX
 
-Trigger it with the `af` CLI (requires af ≥ 0.1.86) — it streams live progress and prints the result:
+Trigger it with the `af` CLI (requires af ≥ 0.1.87) — it streams live progress and prints the result:
 
 ```bash
 af call pr-af.review --in '{"pr_url": "https://github.com/owner/repo/pull/123"}'


### PR DESCRIPTION
## What

Lead the README quickstart with the `af call` CLI command, keeping the existing `curl` example right below as the raw-HTTP alternative.

## Why

The `af` CLI now ships a human trigger surface (`af call` / `af ls` / `af tail`), released in **af 0.1.86** (agentfield #605). `af call <node>.<reasoner> --in '{...}'` streams live progress and prints the result in a single command — a friction-free first-run experience compared to `curl` to an async endpoint and then polling for the result. Curl stays documented for anyone who prefers raw HTTP.

Verified `af call` / `af ls` / `af tail` end-to-end against a freshly installed af 0.1.86 before opening these.