### PR TITLE
feat: env-configurable review budget caps (PR_AF_MAX_DURATION_SECONDS / PR_AF_MAX_COST_USD)

### DIFF
--- a/src/pr_af/app.py
+++ b/src/pr_af/app.py
@@ -59,6 +59,24 @@ def _extract_pr_number(pr_url: str) -> int | None:
     return None
 
 
+def _resolve_budget_caps(
+    max_cost_usd: float | None, max_duration_seconds: int | None
+) -> tuple[float, int]:
+    """Resolve the review budget caps.
+
+    When the caller does not pass an explicit value, fall back to the
+    ``PR_AF_MAX_COST_USD`` / ``PR_AF_MAX_DURATION_SECONDS`` env vars (so the
+    budget can be tuned per deployment without a code change), and finally to
+    the historical defaults (2.0 USD / 300s) when neither is set. An explicit
+    argument always wins over the env var.
+    """
+    if max_cost_usd is None:
+        max_cost_usd = float(os.getenv("PR_AF_MAX_COST_USD", "2.0"))
+    if max_duration_seconds is None:
+        max_duration_seconds = int(os.getenv("PR_AF_MAX_DURATION_SECONDS", "300"))
+    return max_cost_usd, max_duration_seconds
+
+
 def _checkout_pr_branch(target_dir: str, pr_number: int) -> None:
     git_env = {**os.environ, "GIT_TERMINAL_PROMPT": "0", "GIT_ASKPASS": "echo"}
     # Fetch the PR head into FETCH_HEAD rather than directly into a local
@@ -166,8 +184,8 @@ async def review(
     base_ref: str | None = None,
     head_ref: str | None = None,
     depth: str = "auto",
-    max_cost_usd: float = 2.0,
-    max_duration_seconds: int = 300,
+    max_cost_usd: float | None = None,
+    max_duration_seconds: int | None = None,
     focus: str = "auto",
     ignore_paths: list[str] | None = None,
     hints: list[str] | None = None,
@@ -185,6 +203,9 @@ async def review(
         f"diff_text={'<set>' if diff_text else None}, repo_path={repo_path!r}, "
         f"depth={depth!r}, dry_run={dry_run!r}",
         flush=True,
+    )
+    max_cost_usd, max_duration_seconds = _resolve_budget_caps(
+        max_cost_usd, max_duration_seconds
     )
     review_input = ReviewInput(
         pr_url=pr_url,

--- a/tests/test_budget_env.py
+++ b/tests/test_budget_env.py
@@ -1,0 +1,38 @@
+"""Tests for env-configurable review budget caps.
+
+Maps to the validation contract for ``_resolve_budget_caps``:
+
+* caller passes no value + env set -> env value is used
+* caller passes no value + env unset -> historical defaults (2.0 USD / 300s)
+* caller passes an explicit value -> it wins over the env var
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pr_af.app import _resolve_budget_caps
+
+
+def test_env_overrides_when_no_explicit_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PR_AF_MAX_DURATION_SECONDS", "1800")
+    monkeypatch.setenv("PR_AF_MAX_COST_USD", "5")
+    cost, duration = _resolve_budget_caps(None, None)
+    assert duration == 1800
+    assert cost == 5.0
+
+
+def test_defaults_when_env_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("PR_AF_MAX_DURATION_SECONDS", raising=False)
+    monkeypatch.delenv("PR_AF_MAX_COST_USD", raising=False)
+    cost, duration = _resolve_budget_caps(None, None)
+    assert duration == 300
+    assert cost == 2.0
+
+
+def test_explicit_value_wins_over_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PR_AF_MAX_DURATION_SECONDS", "1800")
+    monkeypatch.setenv("PR_AF_MAX_COST_USD", "5")
+    cost, duration = _resolve_budget_caps(7.0, 900)
+    assert duration == 900
+    assert cost == 7.0


### PR DESCRIPTION
## Summary

The review budget caps (`max_duration_seconds`, `max_cost_usd`) were only settable per-call via the `review()` reasoner args. github-buddy calls `pr-af.review` without passing them, so every review used the **hardcoded defaults (300s / \$2)**.

On any non-trivial PR the 300s cap is exhausted during the anatomy + meta phases (anatomy alone takes ~200–260s) **before `review_dimension` runs**, so the pipeline identifies risks but produces **zero scored findings** → no review posted, no HITL gate. There was no way to raise the cap without a code change, because the value is unconditionally taken from the reasoner default.

## Change

Add `_resolve_budget_caps()`: when the caller passes no explicit value, fall back to the **`PR_AF_MAX_DURATION_SECONDS`** / **`PR_AF_MAX_COST_USD`** env vars, then to the historical `300s` / `\$2` defaults.

- **Defaults are unchanged** when the env vars are unset (no behavior change).
- An explicit per-call arg still wins over the env var.
- `max_cost_usd` / `max_duration_seconds` reasoner params become `… | None = None`, matching the existing `int | None = None` params on the same reasoner (`max_concurrent_reviewers`, `max_coverage_iterations`), so reasoner registration is unaffected.
- Mirrors the existing `PR_AF_*` env pattern in `config.py`.

After merge + deploy, set `PR_AF_MAX_DURATION_SECONDS=1800` on the pr-af service to let reviews complete.

## Tests

`tests/test_budget_env.py` — env override used when no explicit value; historical defaults when env unset; explicit arg wins over env.

## Validation

- `ruff check src/ scripts/` — passes (CI lint gate)
- New tests pass; full suite green except one **pre-existing**, unrelated flaky timeout test (`test_create_request_fails_fast_when_hax_wedges`), which fails identically on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)