### PR TITLE
Add missing .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,63 @@
+# --- Secrets ---
+# Required for LLM calls (OpenRouter / opencode harness)
+OPENROUTER_API_KEY=
+
+# GitHub PAT for clone/post; optional if using GitHub App auth below
+GH_TOKEN=
+
+# --- AgentField ---
+AGENTFIELD_SERVER=http://localhost:8080
+AGENTFIELD_API_KEY=
+# Use http://pr-af:8004 when running via docker compose; http://127.0.0.1:8004 when running on host
+AGENT_CALLBACK_URL=http://127.0.0.1:8004
+# Public CP URL for HITL webhooks (Railway cross-project); leave empty for local single-project setups
+AGENTFIELD_PUBLIC_URL=
+NODE_ID=pr-af
+
+# --- AI / harness config ---
+PR_AF_PROVIDER=opencode
+PR_AF_MODEL=openrouter/moonshotai/kimi-k2.5
+# Falls back to PR_AF_MODEL when unset
+PR_AF_AI_MODEL=
+PR_AF_MAX_TURNS=50
+PR_AF_AI_MAX_RETRIES=3
+PR_AF_AI_INITIAL_BACKOFF_SECONDS=2.0
+PR_AF_AI_MAX_BACKOFF_SECONDS=8.0
+PR_AF_OPENCODE_BIN=opencode
+PR_AF_OPENCODE_SERVER=
+
+# Alternate LLM provider keys (forwarded to harness when set)
+ANTHROPIC_API_KEY=
+OPENAI_API_KEY=
+GOOGLE_API_KEY=
+
+# --- Review budget / repo paths ---
+PR_AF_MAX_COST_USD=2.0
+PR_AF_MAX_DURATION_SECONDS=300
+PR_AF_WORKDIR=/workspaces
+# Defaults to cwd when unset
+PR_AF_REPO_PATH=
+# Use /home/praf/.local/share in docker; set a host path when running outside docker
+XDG_DATA_HOME=/home/praf/.local/share
+
+# --- GitHub auth alternatives + webhooks ---
+GITHUB_APP_ID=
+GITHUB_APP_PRIVATE_KEY=
+GITHUB_WEBHOOK_SECRET=
+PR_AF_BOT_MENTION=@pr-af
+
+# --- Human-in-the-loop (optional) ---
+# Set HAX_API_KEY to enable HITL review gate
+HAX_API_KEY=
+HAX_SDK_URL=http://localhost:3000
+AGENTFIELD_APPROVAL_USER_ID=
+
+# --- CI script (optional for local dev) ---
+# Required only when running scripts/ci_runner.py
+PR_URL=
+
+# --- Docker Compose agentfield service ---
+# Used by docker compose up; not read by PR-AF Python code directly
+AF_MODE=dev
+AGENTFIELD_HTTP_ADDR=0.0.0.0:8080
+AGENTFIELD_STORAGE_MODE=local

--- a/.env.example
+++ b/.env.example
@@ -18,7 +18,7 @@ NODE_ID=pr-af
 PR_AF_PROVIDER=opencode
 PR_AF_MODEL=openrouter/moonshotai/kimi-k2.5
 # Falls back to PR_AF_MODEL when unset
-PR_AF_AI_MODEL=
+# PR_AF_AI_MODEL=
 PR_AF_MAX_TURNS=50
 PR_AF_AI_MAX_RETRIES=3
 PR_AF_AI_INITIAL_BACKOFF_SECONDS=2.0


### PR DESCRIPTION
## Summary
- Adds the missing `.env.example` for local and Docker PR-AF setup.
- Documents AgentField, GitHub, provider, budget, HITL, CI, and Docker Compose environment variables.
- Keeps `PR_AF_AI_MODEL` as a commented optional override so it falls back to `PR_AF_MODEL` unless explicitly set.

## Validation
- `uv run --python 3.12 --extra dev pytest -q`
- copied `.env.example` env-load smoke test for `AIIntegrationConfig` fallback behavior
- `git diff --check origin/main...HEAD`