### PR TITLE
hitl: attribute HITL requests to PR-AF via sender manifest

### DIFF
--- a/src/pr_af/hitl/client.py
+++ b/src/pr_af/hitl/client.py
@@ -98,11 +98,18 @@ async def create_hax_form_request_with_timeout(
         tags=["hitl", "hax", "create_request"],
     )
 
+    # Attribute the request to this node so the hub shows PR-AF as the sender
+    # instead of "Unknown sender". Defaults to NODE_ID, env-overridable.
+    _sender_name = os.getenv("HAX_SENDER_NAME") or os.getenv("NODE_ID", "pr-af")
     kwargs: dict[str, Any] = {
         "type": request_type,
         "payload": payload,
         "title": title,
         "expires_in_seconds": expires_in_seconds,
+        "sender": {
+            "key": os.getenv("HAX_SENDER_KEY", _sender_name),
+            "display_name": _sender_name,
+        },
     }
     if description is not None:
         kwargs["description"] = description


### PR DESCRIPTION
## Problem

PR-AF creates hax-sdk HITL review requests via the `hax` SDK's `create_request`, but never passed a `sender`. As a result the Response Hub displayed these requests as **"Unknown sender"** with no indication they originated from PR-AF.

## Change

In `src/pr_af/hitl/client.py` (`create_hax_form_request_with_timeout`, where the `create_request` kwargs are built), add a `sender` manifest:

```python
_sender_name = os.getenv("HAX_SENDER_NAME") or os.getenv("NODE_ID", "pr-af")
kwargs["sender"] = {
    "key": os.getenv("HAX_SENDER_KEY", _sender_name),
    "display_name": _sender_name,
}
```

- Defaults to the node's own identity (`NODE_ID`, falling back to `"pr-af"`).
- Env-overridable via `HAX_SENDER_NAME` (display name) and `HAX_SENDER_KEY` (stable key).
- A plain dict is normalized to the wire `SenderManifest` by the hax SDK, so no extra import is required.

The hub will now attribute these requests to PR-AF instead of "Unknown sender".

## Scope

One file, +7 lines. No behavior change beyond adding the `sender` field. `import os` was already present.

## Gates

- `ruff check src/ scripts/` (CI gate) — pass
- `mypy src/pr_af/hitl/client.py` — pass
- `pytest` — 69 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)