### PR TITLE
chore: add agentfield-package.yaml manifest for `af install`

### DIFF
--- a/agentfield-package.yaml
+++ b/agentfield-package.yaml
@@ -1,0 +1,43 @@
+name: pr-af
+version: 0.1.0
+description: Opens draft pull requests from a task description
+author: Agent-Field
+
+entrypoint:
+  start: python -m pr_af.app
+  healthcheck: /health
+
+agent_node:
+  node_id: pr-af
+  default_port: 8004
+
+user_environment:
+  required:
+    - name: OPENROUTER_API_KEY
+      description: LLM provider key (OpenRouter)
+      type: secret
+      scope: global
+  optional:
+    - name: AGENTFIELD_SERVER
+      description: Control-plane URL
+      default: http://localhost:8080
+    - name: AGENTFIELD_API_KEY
+      description: Control-plane API key (if auth is enabled)
+      type: secret
+      scope: global
+    - name: GH_TOKEN
+      description: GitHub token for cloning repos / opening PRs
+      type: secret
+      scope: global
+    - name: PR_AF_PROVIDER
+      description: Coding-agent harness provider
+      default: opencode
+    - name: PR_AF_MODEL
+      description: Model the harness uses
+      default: openrouter/moonshotai/kimi-k2.5
+    - name: PR_AF_MAX_COST_USD
+      description: Per-run cost ceiling (USD)
+      default: "2.0"
+    - name: PR_AF_MAX_DURATION_SECONDS
+      description: Per-run wall-clock ceiling (seconds)
+      default: "300"

--- a/agentfield-package.yaml
+++ b/agentfield-package.yaml
@@ -1,3 +1,4 @@
+config_version: v1            # manifest schema version (omit = legacy v0)
 name: pr-af
 version: 0.1.0
 description: Opens draft pull requests from a task description
@@ -17,16 +18,19 @@ user_environment:
       description: LLM provider key (OpenRouter)
       type: secret
       scope: global
+    # pr-af's core loop clones the target repo, pushes a branch, and opens a
+    # pull request — all need GitHub write access (see app.py / github/client.py).
+    # Required so setup prompts for it up front instead of failing mid-run.
+    - name: GH_TOKEN
+      description: GitHub token (repo scope) for cloning repos and opening pull requests
+      type: secret
+      scope: global
   optional:
     - name: AGENTFIELD_SERVER
       description: Control-plane URL
       default: http://localhost:8080
     - name: AGENTFIELD_API_KEY
       description: Control-plane API key (if auth is enabled)
-      type: secret
-      scope: global
-    - name: GH_TOKEN
-      description: GitHub token for cloning repos / opening PRs
       type: secret
       scope: global
     - name: PR_AF_PROVIDER


### PR DESCRIPTION
Adds an `agentfield-package.yaml` manifest so **pr-af** can be installed and run locally with `af install` / `af run` (control-plane support: Agent-Field/agentfield#692).

The manifest declares the entrypoint, default port, and required/optional environment (derived from this repo's `.env.example` and app entrypoint). The required LLM key is marked `type: secret, scope: global` so it is prompted once, shared across nodes, and stored encrypted — never committed in plaintext.

🤖 Generated with [Claude Code](https://claude.com/claude-code)