### PR TITLE
fix: honor PORT injected by `af run` (unbreak install-and-run)

### DIFF
--- a/src/pr_af/app.py
+++ b/src/pr_af/app.py
@@ -378,7 +378,12 @@ app.include_router(reasoner_router)
 
 
 def main() -> None:
-    app.run(port=8004, host="0.0.0.0")
+    # Honor the PORT injected by the AgentField CLI/runner (`af run` allocates a
+    # free port and passes it via PORT); fall back to 8004 when launched
+    # standalone. Previously this was hardcoded to 8004, which the SDK treats as
+    # an explicit override — so `af run pr-af` bound 8004 while the CLI polled its
+    # assigned port, and the readiness check timed out.
+    app.run(port=int(os.getenv("PORT", "8004")), host="0.0.0.0")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

`af run pr-af` fails its readiness check:

```
❌ Failed to run agent: agent node failed to start: agent node did not become ready within 10s
```

`pr_af/app.py` calls `app.run(port=8004, host="0.0.0.0")` with a **hardcoded** port. The SDK treats an explicitly-passed port as the highest-priority override, so it ignores the `PORT` environment variable the AgentField runner injects after it allocates a free port. The node binds 8004 while the CLI polls the port it assigned (e.g. 8001), so the health poll never sees the node and times out.

The other agent nodes (sec-af, cloudsecurity-af) already read `PORT` and run fine on `af run`; pr-af was the only one hardcoding it.

## Fix

```python
app.run(port=int(os.getenv("PORT", "8004")), host="0.0.0.0")
```

Honors the runner-injected `PORT`, keeps 8004 as the standalone default (`python -m pr_af.app`). `os` is already imported.

## Verification

Installed the patched node and launched it directly with `PORT=8011`:

```
ℹ️ Starting agent node 'pr-af' on port 8011
INFO:     Uvicorn running on http://0.0.0.0:8011
$ curl localhost:8011/health → {"node_id":"pr-af", ...}
```

Pre-fix it bound 8004 regardless of `PORT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)