### PR TITLE
fix(docker): honor PR_AF_MODEL in the opencode harness config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,13 +52,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     chown -R praf:praf /app /workspaces /home/praf && \
     rm -rf /var/lib/apt/lists/*
 
-RUN mkdir -p /home/praf/.config/opencode && \
-    echo '{"$schema":"https://opencode.ai/config.json","model":"openrouter/moonshotai/kimi-k2.5","small_model":"openrouter/moonshotai/kimi-k2.5","provider":{"openrouter":{"options":{"apiKey":"{env:OPENROUTER_API_KEY}"},"models":{"moonshotai/kimi-k2.5":{}}}}}' \
-    > /home/praf/.config/opencode/opencode.json && \
-    chown -R praf:praf /home/praf/.config
-
 COPY --from=builder /install /usr/local
 COPY src/ /app/src/
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 USER praf
 
@@ -67,4 +64,5 @@ EXPOSE 8004
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
     CMD curl -f http://localhost:8004/health || exit 1
 
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["python", "-m", "pr_af.app"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Generate the opencode config at container start so PR_AF_MODEL is honored.
+#
+# Previously opencode.json was baked into the image with a hardcoded model and
+# a single-model provider whitelist. That meant PR_AF_MODEL was ignored by the
+# opencode harness: even though the model is passed via `-m`, opencode fell back
+# to (and restricted itself to) the baked model. Generating the config here from
+# PR_AF_MODEL fixes that — the env var wins when set, and we fall back to the
+# benchmarked default when it isn't.
+set -e
+
+# Default matches the image ENV / benchmarked model.
+MODEL="${PR_AF_MODEL:-openrouter/moonshotai/kimi-k2.5}"
+
+# opencode keys models under a provider by the slug *without* the provider
+# prefix, e.g. "openrouter/z-ai/glm-5.2" -> provider "openrouter", key "z-ai/glm-5.2".
+MODEL_KEY="${MODEL#openrouter/}"
+
+CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/opencode"
+mkdir -p "$CONFIG_DIR"
+
+cat > "$CONFIG_DIR/opencode.json" <<EOF
+{"\$schema":"https://opencode.ai/config.json","model":"${MODEL}","small_model":"${MODEL}","provider":{"openrouter":{"options":{"apiKey":"{env:OPENROUTER_API_KEY}"},"models":{"${MODEL_KEY}":{}}}}}
+EOF
+
+exec "$@"


### PR DESCRIPTION
## Problem

The opencode harness config (`~/.config/opencode/opencode.json`) is baked into the image at build time with a **hardcoded model** and a **single-model provider whitelist**:

```json
{"model":"openrouter/moonshotai/kimi-k2.5","small_model":"openrouter/moonshotai/kimi-k2.5",
 "provider":{"openrouter":{"models":{"moonshotai/kimi-k2.5":{}}}}}
```

Because of this, setting `PR_AF_MODEL` had **no effect on the opencode provider**. The harness does pass the model via `-m` (`sdk .../providers/opencode.py`), but opencode still fell back to — and restricted itself to — the baked model/whitelist. So e.g. `PR_AF_MODEL=openrouter/z-ai/glm-5.2` was silently ignored.

## Fix

Generate `opencode.json` at container start from `PR_AF_MODEL` via a small entrypoint script, deriving the provider model key by stripping the `openrouter/` prefix. The env var now wins when set; when unset it falls back to the same benchmarked default.

- `PR_AF_MODEL=openrouter/z-ai/glm-5.2` → `model`/`small_model` = that model, whitelist key `z-ai/glm-5.2`.
- `PR_AF_MODEL` unset → generated config is **byte-identical** to the previous baked default (verified), so no behavior change.

## Validation contract

| Behavior | Result |
|---|---|
| `PR_AF_MODEL` set → config `model`, `small_model`, and provider whitelist all reflect it | ✅ |
| `PR_AF_MODEL` unset → config identical to prior baked default | ✅ (byte-diff clean) |
| `apiKey` templating `{env:OPENROUTER_API_KEY}` preserved | ✅ |
| Entrypoint `exec`s the CMD (PID 1 / signals / exit code pass through) | ✅ |

Tested by running the real `docker-entrypoint.sh` under both env states and parsing the emitted JSON.

## Note

Full image build + a live review run against a real PR is still pending (blocked on Railway access on my side); this change is verified at the config-generation layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)