### PR TITLE
docs: add one-click "Deploy on Railway" badge to Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,26 @@ There are excellent AI code review tools on the market. PR-AF is not designed to
 
 ## Quick Start
 
+### Deploy with Railway (fastest)
+
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/pr-af)
+
+One click deploys PR-AF + the AgentField control plane + PostgreSQL. Set two environment variables in Railway:
+
+- `OPENROUTER_API_KEY` — your [OpenRouter](https://openrouter.ai/keys) key (routes to the review models)
+- `GH_TOKEN` — GitHub personal access token with `repo` scope, for reading PRs and posting reviews
+
+Once deployed, trigger a review against the control plane (the public endpoint requires the `X-API-Key` header set to your `AGENTFIELD_API_KEY`):
+
+```bash
+curl -X POST https://<control-plane>.up.railway.app/api/v1/execute/async/pr-af.review \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: <AGENTFIELD_API_KEY>" \
+  -d '{"input": {"pr_url": "https://github.com/owner/repo/pull/123"}}'
+```
+
+### Run locally (Docker Compose)
+
 ```bash
 git clone https://github.com/Agent-Field/pr-af.git && cd pr-af
 cp .env.example .env          # Add OPENROUTER_API_KEY, GH_TOKEN


### PR DESCRIPTION
Adds the one-click **Deploy on Railway** badge to the PR-AF README, linking the existing template at `railway.com/deploy/pr-af`.

## Why

PR-AF ships a Railway template but the README never surfaced it. **SWE-AF** and **sec-af** already expose theirs as a *"Deploy with Railway (fastest)"* subsection under Quick Start — this mirrors that exact pattern (same `railway.com/button.svg` badge form) so the three agents are consistent and the template is one click from the README.

## Change

- New `### Deploy with Railway (fastest)` subsection at the top of Quick Start with the badge, the two required env vars (`OPENROUTER_API_KEY`, `GH_TOKEN`), and a trigger example against the hosted control plane.
- Existing docker-compose instructions relabeled `### Run locally (Docker Compose)` so hosted vs local read clearly.

README-only; no code or behavior change. Both `railway.com/button.svg` and `railway.com/deploy/pr-af` verified returning 200.

Badge:

```markdown
[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/pr-af)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)