### PR TITLE
docs: document `af install` into an AgentField setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,25 @@ There are excellent AI code review tools on the market. PR-AF is not designed to
 
 ## Quick Start
 
+### Install into AgentField (`af install`)
+
+Already running an [AgentField](https://github.com/Agent-Field/agentfield) control plane? Install PR-AF straight from GitHub — no clone, no local setup:
+
+```bash
+af install https://github.com/Agent-Field/pr-af
+af run pr-af
+```
+
+`af install` clones the repo, provisions an isolated Python environment, and registers the `pr-af` node with your control plane. On first `af run` you're prompted for the required secrets — `OPENROUTER_API_KEY` and `GH_TOKEN` — which are stored encrypted and reused across every node, so you enter each only once. Then review a PR:
+
+```bash
+af call pr-af.review --in '{"pr_url": "https://github.com/owner/repo/pull/123"}'
+```
+
+New to AgentField? Install the control plane first with `curl -fsSL https://agentfield.ai/install.sh | bash`, or use the Docker option below.
+
+### Local (Docker Compose)
+
 ```bash
 git clone https://github.com/Agent-Field/pr-af.git && cd pr-af
 cp .env.example .env          # Add OPENROUTER_API_KEY, GH_TOKEN


### PR DESCRIPTION
Adds an **Install into AgentField** subsection at the top of Quick Start, documenting the one-command install path for users who already run an [AgentField](https://github.com/Agent-Field/agentfield) control plane:

```bash
af install https://github.com/Agent-Field/pr-af
af run <node>
af call <node>.<reasoner> --in '{...}'
```

Explains that `af install` clones the repo, provisions an isolated env, and registers the node; required secrets (e.g. `OPENROUTER_API_KEY`) are prompted once on first `af run`, stored encrypted, and reused across every node. Existing Railway/Docker/local instructions are unchanged. Verified against v0.1.105 (this exact flow installs and runs out of the box).

🤖 Generated with [Claude Code](https://claude.com/claude-code)