### PR TITLE
fix: don't hard-fail reviews on GLM providers / large PRs

### DIFF
--- a/src/pr_af/github/client.py
+++ b/src/pr_af/github/client.py
@@ -204,11 +204,26 @@ class GitHubClient:
                 commit_page += 1
 
             diff_headers = {**auth_headers, "Accept": "application/vnd.github.v3.diff"}
-            diff_resp = await client.get(
-                f"{self.base_url}/repos/{owner}/{repo}/pulls/{number}",
-                headers=diff_headers,
-            )
-            diff_resp.raise_for_status()
+            try:
+                diff_resp = await client.get(
+                    f"{self.base_url}/repos/{owner}/{repo}/pulls/{number}",
+                    headers=diff_headers,
+                )
+                diff_resp.raise_for_status()
+                full_diff = diff_resp.text
+            except httpx.HTTPStatusError as exc:
+                # GitHub returns 406 for the one-shot .diff media type when a
+                # PR's diff is too large to generate (very large PRs). The
+                # per-file patches were already fetched from the /files API
+                # above, so reconstruct an equivalent unified diff from them
+                # instead of failing the whole review.
+                if exc.response.status_code != 406:
+                    raise
+                full_diff = "\n".join(
+                    f"diff --git a/{f.path} b/{f.path}\n--- a/{f.path}\n+++ b/{f.path}\n{f.patch}"
+                    for f in changed_files
+                    if f.patch
+                )
 
         return GitHubPRData(
             owner=owner,
@@ -221,7 +236,7 @@ class GitHubClient:
             base_sha=pr_data.get("base", {}).get("sha", ""),
             head_sha=pr_data.get("head", {}).get("sha", ""),
             commit_messages=commit_messages,
-            diff=diff_resp.text,
+            diff=full_diff,
             changed_files=changed_files,
         )
 

--- a/src/pr_af/reasoners/harnesses.py
+++ b/src/pr_af/reasoners/harnesses.py
@@ -260,13 +260,19 @@ async def intake_phase(pr_data: dict, depth: str = "standard") -> dict:
         default=str,
     )
 
-    gate_result = await router.app.ai(
-        f"Classify this pull request from metadata and diff footprint.\n\n{ai_input}",
-        system="Return pr_type, complexity, and confident only. Use the provided schema.",
-        schema=IntakeGate,
-    )
+    try:
+        gate_result = await router.app.ai(
+            f"Classify this pull request from metadata and diff footprint.\n\n{ai_input}",
+            system="Return pr_type, complexity, and confident only. Use the provided schema.",
+            schema=IntakeGate,
+        )
+    except Exception:
+        # Some providers/harnesses (e.g. GLM via an OpenAI-compatible endpoint)
+        # do not support the structured-output request .ai() issues. Rather than
+        # sink the whole review, fall through to the harness classifier below.
+        gate_result = None
 
-    if gate_result.confident:
+    if gate_result is not None and gate_result.confident:
         paths = [changed.path for changed in pr.changed_files]
         areas_touched = _extract_areas(paths)
         intake_result = IntakeResult(
@@ -1688,12 +1694,21 @@ async def coverage_gate(
         },
         default=str,
     )
-    gate = await router.app.ai(
+    coverage_prompt = (
         f"Determine whether review coverage is complete. "
         f"Compare reviewed cluster identifiers against all change clusters. "
         f"Dimensions already reviewed: {', '.join(dimension_names_reviewed or [])}. "
-        f"If gaps exist, return concise gap_descriptions.\n\n{context}",
-        system="Analyze the coverage state and return the structured result.",
-        schema=CoverageGate,
+        f"If gaps exist, return concise gap_descriptions.\n\n{context}"
     )
-    return gate.model_dump()
+    try:
+        gate = await router.app.ai(
+            coverage_prompt,
+            system="Analyze the coverage state and return the structured result.",
+            schema=CoverageGate,
+        )
+        return gate.model_dump()
+    except Exception:
+        # Structured output via .ai() may be unsupported by the configured
+        # provider; fall back to the harness so coverage still runs.
+        gate = await router.app.harness(coverage_prompt, schema=CoverageGate)
+        return gate.parsed.model_dump() if gate.parsed else {}


### PR DESCRIPTION
## What & why

Two robustness fixes found while running pr-af against a self-hosted GLM setup (opencode with an OpenAI-compatible Z.ai endpoint) and against very large PRs. Both currently cause an entire review to fail.

### 1. `.ai()` structured-output calls hard-fail on some providers
`intake_phase` and the coverage gate call `router.app.ai(..., schema=...)`, which requests structured output (`response_format`). Providers that don't support that parameter (e.g. GLM via litellm's `zai` provider) raise, and because the intake call is unguarded the whole review dies. Both `.ai()` calls are now wrapped and fall back to the existing `.harness()` path — intake already had a harness classifier; coverage now uses one on failure.

### 2. Large PRs 406 on the diff media type
`_fetch_pr_once` fetches the PR diff via `Accept: application/vnd.github.v3.diff`. GitHub returns **406 Not Acceptable** when the diff is too large to generate (observed on a 722-file PR). The per-file patches are already fetched from the `/files` API just above, so on 406 we reconstruct an equivalent unified diff from them instead of failing.

## Testing
- A GLM (opencode/Z.ai) review that previously died at intake now completes and posts.
- A 722-file PR that previously 406'd now fetches (≈3.5 MB reconstructed diff) and reviews to completion.
- Small-PR path unchanged — the normal `.diff` media type and `.ai()` are still used when they succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
