### PR TITLE
fix: reconstruct diff from per-file patches when GitHub 406s on large PRs

### DIFF
--- a/src/pr_af/github/client.py
+++ b/src/pr_af/github/client.py
@@ -204,11 +204,26 @@ class GitHubClient:
                 commit_page += 1
 
             diff_headers = {**auth_headers, "Accept": "application/vnd.github.v3.diff"}
-            diff_resp = await client.get(
-                f"{self.base_url}/repos/{owner}/{repo}/pulls/{number}",
-                headers=diff_headers,
-            )
-            diff_resp.raise_for_status()
+            try:
+                diff_resp = await client.get(
+                    f"{self.base_url}/repos/{owner}/{repo}/pulls/{number}",
+                    headers=diff_headers,
+                )
+                diff_resp.raise_for_status()
+                full_diff = diff_resp.text
+            except httpx.HTTPStatusError as exc:
+                # GitHub returns 406 for the one-shot .diff media type when a
+                # PR's diff is too large to generate (very large PRs). The
+                # per-file patches were already fetched from the /files API
+                # above, so reconstruct an equivalent unified diff from them
+                # instead of failing the whole review.
+                if exc.response.status_code != 406:
+                    raise
+                full_diff = "\n".join(
+                    f"diff --git a/{f.path} b/{f.path}\n--- a/{f.path}\n+++ b/{f.path}\n{f.patch}"
+                    for f in changed_files
+                    if f.patch
+                )
 
         return GitHubPRData(
             owner=owner,
@@ -221,7 +236,7 @@ class GitHubClient:
             base_sha=pr_data.get("base", {}).get("sha", ""),
             head_sha=pr_data.get("head", {}).get("sha", ""),
             commit_messages=commit_messages,
-            diff=diff_resp.text,
+            diff=full_diff,
             changed_files=changed_files,
         )
 


### PR DESCRIPTION
## Problem

`_fetch_pr_once` fetches the PR diff via `Accept: application/vnd.github.v3.diff`. GitHub returns **406 Not Acceptable** when the diff is too large to generate — reproduced on a 722-file PR. `diff_resp.raise_for_status()` then aborts the whole review, so large PRs can't be reviewed at all.

## Fix

The per-file patches are already fetched from the `/pulls/{n}/files` API a few lines above. On a 406, reconstruct an equivalent unified diff from those patches instead of failing:

```python
except httpx.HTTPStatusError as exc:
    if exc.response.status_code != 406:
        raise
    full_diff = "\n".join(
        f"diff --git a/{f.path} b/{f.path}\n--- a/{f.path}\n+++ b/{f.path}\n{f.patch}"
        for f in changed_files if f.patch
    )
```

Small/normal PRs are unchanged — the real `.diff` media type is still used whenever it succeeds.

## Testing

A 722-file PR that previously 406'd now fetches (≈3.5 MB reconstructed diff) and reviews to completion.

## Note

GitHub's `/files` API caps at 3000 files and omits `patch` for individually huge files, so extreme PRs may have partial diffs — but a partial diff is strictly better than a hard failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
