### PR TITLE
feat: thread aforge harness binary path through node config

### DIFF
--- a/src/pr_af/app.py
+++ b/src/pr_af/app.py
@@ -40,6 +40,7 @@ app = Agent(
         max_turns=_ai_config.max_turns,
         env=_ai_config.provider_env(),
         opencode_bin=_ai_config.opencode_bin,
+        aforge_bin=_ai_config.aforge_bin,
         permission_mode="auto",
     ),
     ai_config=AIConfig(

--- a/src/pr_af/config.py
+++ b/src/pr_af/config.py
@@ -314,6 +314,7 @@ class AIIntegrationConfig(BaseModel):
     max_backoff_seconds: float = Field(default_factory=lambda: float(os.getenv("PR_AF_AI_MAX_BACKOFF_SECONDS", "8.0")))
     opencode_bin: str = Field(default_factory=lambda: os.getenv("PR_AF_OPENCODE_BIN", "opencode"))
     opencode_server: str | None = Field(default_factory=lambda: os.getenv("PR_AF_OPENCODE_SERVER"))
+    aforge_bin: str = Field(default_factory=lambda: os.getenv("PR_AF_AFORGE_BIN", "aforge"))
 
     @classmethod
     def from_env(cls) -> AIIntegrationConfig:


### PR DESCRIPTION
## Summary
Adds `PR_AF_AFORGE_BIN` (default `aforge`) and threads it into `HarnessConfig.aforge_bin`, so a node started with `PR_AF_PROVIDER=aforge` can point at a specific aforge binary. Companion to Agent-Field/agentfield#891 (which adds the aforge harness provider) and Agent-Field/aforge-v2#1 (which adds aforge's one-shot exec mode). `PR_AF_PROVIDER=aforge` itself already passes through untouched — the provider field is a plain string.

## Changes Made
- `config.py`: `aforge_bin` field on `AIIntegrationConfig`, sourced from `PR_AF_AFORGE_BIN`
- `app.py`: pass `aforge_bin` into `HarnessConfig`

With SDKs that predate the aforge provider, `HarnessConfig` ignores the extra field (pydantic `extra="ignore"`), so this is inert until the SDK supports it.

## Test Plan
- [x] `ruff check src/ scripts/` clean
- [x] `docker build` gate passes
- [x] Config smoke: `PR_AF_AFORGE_BIN=/x/aforge` → `AIIntegrationConfig.from_env().aforge_bin == "/x/aforge"`
- [ ] Live node smoke with the new SDK (running as part of an aforge-vs-opencode head-to-head; will report back on this PR)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)