### PR TITLE
Fail closed on empty review plans

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ The key knobs (see `.env.example` for the full list):
 | `PR_AF_MODEL`               | Harness model (default `openrouter/moonshotai/kimi-k2.5`)      |
 | `PR_AF_MAX_COST_USD`        | Per-run cost ceiling in USD (default `2.0`)                    |
 | `PR_AF_MAX_DURATION_SECONDS`| Per-run wall-clock ceiling in seconds (default `3600`)         |
-| `AGENTFIELD_HARNESS_IDLE_SECONDS` | Harness no-output watchdog window in seconds (default `360`) — harness CLIs in JSON mode emit events only at completion boundaries, so long single completions look silent |
+| `AGENTFIELD_HARNESS_IDLE_SECONDS` | Harness no-output watchdog window in seconds (default `1200`) — harness CLIs in JSON mode emit events only at completion boundaries, and large-PR phases can take more than ten minutes |
 | `PR_AF_WORKDIR`             | Where PR checkouts live (default `/workspaces`); each PR gets its own `<repo>-pr<N>` workspace |
 
 ## GitHub Actions Integration

--- a/agentfield-package.yaml
+++ b/agentfield-package.yaml
@@ -70,8 +70,9 @@ user_environment:
       description: Per-run wall-clock ceiling (seconds)
       default: "3600"
     # Harness CLIs in JSON mode emit events only at completion boundaries, so a
-    # long single completion looks silent; the old 120s SDK default killed
-    # healthy runs.
+    # long single completion looks silent. Real large-PR phases can exceed ten
+    # minutes, so keep this below the review wall-clock cap but above observed
+    # healthy single-completion latency.
     - name: AGENTFIELD_HARNESS_IDLE_SECONDS
       description: harness no-output watchdog window (seconds)
-      default: "360"
+      default: "1200"

--- a/go/README.md
+++ b/go/README.md
@@ -164,7 +164,7 @@ The node is configured entirely through the environment.
 | `PR_AF_HARNESS_BIN`         | Optional harness executable override for every provider; unset uses provider defaults |
 | `PR_AF_MAX_COST_USD`        | Per-run cost ceiling in USD (default `2.0`)                    |
 | `PR_AF_MAX_DURATION_SECONDS`| Per-run wall-clock ceiling in seconds (default `3600`)         |
-| `AGENTFIELD_HARNESS_IDLE_SECONDS` | Harness no-output watchdog window in seconds (default `360`) — harness CLIs in JSON mode emit events only at completion boundaries, so long single completions look silent |
+| `AGENTFIELD_HARNESS_IDLE_SECONDS` | Harness no-output watchdog window in seconds (default `1200`) — harness CLIs in JSON mode emit events only at completion boundaries, and large-PR phases can take more than ten minutes |
 | `HAX_API_KEY`               | Optional — enables the HITL review-approval gate when set      |
 
 Note: the code default model is `minimax/minimax-m2.5`, while the Docker image /

--- a/go/agentfield-package.yaml
+++ b/go/agentfield-package.yaml
@@ -64,8 +64,9 @@ user_environment:
       description: per-run wall-clock ceiling
       default: "3600"
     # Harness CLIs in JSON mode emit events only at completion boundaries, so a
-    # long single completion looks silent; the old 120s SDK default killed
-    # healthy runs.
+    # long single completion looks silent. Real large-PR phases can exceed ten
+    # minutes, so keep this below the review wall-clock cap but above observed
+    # healthy single-completion latency.
     - name: AGENTFIELD_HARNESS_IDLE_SECONDS
       description: harness no-output watchdog window (seconds)
-      default: "360"
+      default: "1200"

--- a/go/internal/orch/degradation_test.go
+++ b/go/internal/orch/degradation_test.go
@@ -61,6 +61,27 @@ func TestRunFailsBeforeOutputWhenAllDimensionsFailSchemaParsing(t *testing.T) {
 	}
 }
 
+func TestMetaSelectorsFailClosedWhenNoDimensionsAreProduced(t *testing.T) {
+	o := degradationOrchestrator(t)
+	emptyMeta := func(context.Context, reasoners.Deps, reasoners.MetaInput) (map[string]any, error) {
+		return map[string]any{"dimensions": []any{}}, nil
+	}
+	o.rfns.metaSemantic = emptyMeta
+	o.rfns.metaMechanical = emptyMeta
+	o.rfns.metaSystemic = emptyMeta
+
+	_, err := o.runMetaSelectors(
+		context.Background(),
+		schemas.IntakeResult{},
+		schemas.AnatomyResult{},
+		"standard",
+		"",
+	)
+	if err == nil || !strings.Contains(err.Error(), "no review dimensions were produced") {
+		t.Fatalf("runMetaSelectors error = %v, want fail-closed empty-plan error", err)
+	}
+}
+
 func TestMixedAndCleanDimensionsExposeOnlyActualDegradation(t *testing.T) {
 	for _, tc := range []struct {
 		name   string

--- a/go/internal/orch/phases.go
+++ b/go/internal/orch/phases.go
@@ -326,6 +326,11 @@ func (o *Orchestrator) runMetaSelectors(
 		})
 		allDimensions = allDimensions[:profile.MaxDimensions]
 	}
+	if len(allDimensions) == 0 {
+		return schemas.ReviewPlan{}, fmt.Errorf(
+			"no review dimensions were produced; refusing to publish a clean verdict",
+		)
+	}
 
 	// ReviewPlan is NOT default-seeded in schemas (design §5), so seed the
 	// pydantic BudgetAllocation() default for total_budget explicitly — otherwise


### PR DESCRIPTION
## What changed

- refuse to publish a clean verdict when all meta selectors produce an empty review plan
- add a regression test for the empty-plan failure mode
- raise the manifest harness-idle default from 360 to 1200 seconds in both package manifests and documentation

## Why

A missing provider executable can yield unparseable/empty meta-selector outputs. PR-AF previously turned that into a zero-dimension, zero-finding clean review. Large valid OpenCode phases can also exceed the former six-minute no-output watchdog because JSON-mode events arrive only at completion boundaries.

The new guard makes an empty plan terminal, while the longer idle window remains below the one-hour review wall-clock cap and covers observed healthy phase latency above ten minutes.

## Validation

Validated at `d8a9ba20e11bbe7aff052dd1f3bbd5ea83f98051`:

- `go test ./...` — passes for the complete Go module
- `pytest` — 103 passed for the complete Python package
- `git diff --check` — passes
