### PR TITLE
feat: make AForge exec the default harness

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,7 @@ NODE_ID=pr-af
 # --- AI / harness config ---
 # AForge exec is the default. Set PR_AF_PROVIDER=opencode to roll back.
 PR_AF_PROVIDER=aforge
+# Read by the Go node's SDK adapter; the pinned Python SDK always runs `exec`.
 AGENTFIELD_AFORGE_COMMAND=exec
 PR_AF_MODEL=openrouter/moonshotai/kimi-k2.5
 # Falls back to PR_AF_MODEL when unset

--- a/.env.example
+++ b/.env.example
@@ -15,8 +15,9 @@ AGENTFIELD_PUBLIC_URL=
 NODE_ID=pr-af
 
 # --- AI / harness config ---
-# `aforge` selects the unreleased aforge-v2 CLI through AgentField's harness.
-PR_AF_PROVIDER=opencode
+# AForge exec is the default. Set PR_AF_PROVIDER=opencode to roll back.
+PR_AF_PROVIDER=aforge
+AGENTFIELD_AFORGE_COMMAND=exec
 PR_AF_MODEL=openrouter/moonshotai/kimi-k2.5
 # Falls back to PR_AF_MODEL when unset
 # PR_AF_AI_MODEL=

--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,7 @@ AGENTFIELD_PUBLIC_URL=
 NODE_ID=pr-af
 
 # --- AI / harness config ---
+# `aforge` selects the unreleased aforge-v2 CLI through AgentField's harness.
 PR_AF_PROVIDER=opencode
 PR_AF_MODEL=openrouter/moonshotai/kimi-k2.5
 # Falls back to PR_AF_MODEL when unset
@@ -24,6 +25,7 @@ PR_AF_AI_MAX_RETRIES=3
 PR_AF_AI_INITIAL_BACKOFF_SECONDS=2.0
 PR_AF_AI_MAX_BACKOFF_SECONDS=8.0
 PR_AF_OPENCODE_BIN=opencode
+PR_AF_AFORGE_BIN=aforge
 # Optional provider-agnostic harness executable override (leave unset to use provider defaults)
 # PR_AF_HARNESS_BIN=
 PR_AF_OPENCODE_SERVER=

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
+ARG AFORGE_IMAGE=ghcr.io/agent-field/aforge-v2:chat-v2-exec
+FROM ${AFORGE_IMAGE} AS aforge
+
+
 FROM python:3.11-slim AS builder
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
@@ -14,7 +18,7 @@ COPY pyproject.toml README.md ./
 COPY src/ src/
 
 RUN pip install --no-cache-dir --prefix=/install \
-    "agentfield==0.1.126" \
+    "agentfield @ git+https://github.com/Agent-Field/agentfield.git@bfd34426d1bdec3cbbfa946682a22ef0a1b91503#subdirectory=sdk/python" \
     "hax-sdk>=0.2.4" \
     "pydantic>=2.0" \
     "httpx>=0.27" \
@@ -32,7 +36,8 @@ ARG OPENCODE_VERSION=1.17.15
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     AGENTFIELD_SERVER=http://agentfield:8080 \
-    PR_AF_PROVIDER=opencode \
+    PR_AF_PROVIDER=aforge \
+    AGENTFIELD_AFORGE_COMMAND=exec \
     PR_AF_MODEL=openrouter/moonshotai/kimi-k2.5 \
     PORT=8004 \
     HOME=/home/praf \
@@ -55,6 +60,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /install /usr/local
+COPY --from=aforge /aforge /usr/local/bin/aforge
 COPY src/ /app/src/
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 FROM debian:bookworm-slim AS aforge
 
 ARG AFORGE_BASE_URL=https://agentfield.ai/downloads/aforge
-ARG AFORGE_VERSION=build-9b3ff482de3f
+ARG AFORGE_VERSION=v0.1.0
 ARG TARGETARCH
 
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ COPY pyproject.toml README.md ./
 COPY src/ src/
 
 RUN pip install --no-cache-dir --prefix=/install \
-    "agentfield @ git+https://github.com/Agent-Field/agentfield.git@bfd34426d1bdec3cbbfa946682a22ef0a1b91503#subdirectory=sdk/python" \
+    "agentfield>=0.1.129" \
     "hax-sdk>=0.2.4" \
     "pydantic>=2.0" \
     "httpx>=0.27" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,34 @@
-ARG AFORGE_IMAGE=ghcr.io/agent-field/aforge-v2:chat-v2-exec
-FROM ${AFORGE_IMAGE} AS aforge
+# ---------------------------------------------------------------------------
+# Stage 0 — aforge: fetch the released AForge CLI from the public download host
+# and verify it against the release checksums (which hash the DECOMPRESSED
+# binaries). Both ARGs are overridable so CI or a local mirror can serve the
+# assets from somewhere else:
+#
+#     docker build --build-arg AFORGE_BASE_URL=... --build-arg AFORGE_VERSION=... .
+# ---------------------------------------------------------------------------
+FROM debian:bookworm-slim AS aforge
+
+ARG AFORGE_BASE_URL=https://agentfield.ai/downloads/aforge
+ARG AFORGE_VERSION=build-9b3ff482de3f
+ARG TARGETARCH
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /out
+RUN set -eux; \
+    arch="${TARGETARCH:-$(dpkg --print-architecture)}"; \
+    curl -fsSL "${AFORGE_BASE_URL}/${AFORGE_VERSION}/aforge-linux-${arch}.gz" -o aforge.gz; \
+    gunzip -c aforge.gz > aforge; \
+    rm -f aforge.gz; \
+    curl -fsSL "${AFORGE_BASE_URL}/${AFORGE_VERSION}/checksums.txt" -o checksums.txt; \
+    grep " aforge-linux-${arch}$" checksums.txt | sed 's/  aforge-linux-.*/  aforge/' > aforge.sha256; \
+    test -s aforge.sha256; \
+    sha256sum -c aforge.sha256; \
+    rm -f checksums.txt aforge.sha256; \
+    chmod +x aforge
 
 
 FROM python:3.11-slim AS builder
@@ -60,7 +89,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /install /usr/local
-COPY --from=aforge /aforge /usr/local/bin/aforge
+COPY --from=aforge /out/aforge /usr/local/bin/aforge
 COPY src/ /app/src/
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ COPY pyproject.toml README.md ./
 COPY src/ src/
 
 RUN pip install --no-cache-dir --prefix=/install \
-    "agentfield>=0.1.129" \
+    "agentfield>=0.1.130" \
     "hax-sdk>=0.2.4" \
     "pydantic>=2.0" \
     "httpx>=0.27" \

--- a/README.md
+++ b/README.md
@@ -263,19 +263,18 @@ The key knobs (see `.env.example` for the full list):
 |-----------------------------|----------------------------------------------------------------|
 | `OPENROUTER_API_KEY`        | LLM provider key (OpenRouter) — required                       |
 | `GH_TOKEN`                  | GitHub token (`repo` scope) for reading PRs and posting reviews |
-| `PR_AF_PROVIDER`            | Harness provider (default `opencode`; accepts `aforge`)        |
+| `PR_AF_PROVIDER`            | Harness provider (default `aforge`; use `opencode` to roll back) |
+| `AGENTFIELD_AFORGE_COMMAND` | AForge headless command (default `exec`; `do` is explicit)     |
 | `PR_AF_AFORGE_BIN`          | Path to an aforge-v2 binary (default `aforge`)                 |
 | `PR_AF_HARNESS_BIN`         | Provider-agnostic executable override                          |
-
-For an unreleased aforge-v2 source benchmark, build `./cmd/aforge`, then run
-PR-AF with `PR_AF_PROVIDER=aforge` and either `PR_AF_AFORGE_BIN` (Python node)
-or `PR_AF_HARNESS_BIN` (maintained Go node) set to the absolute binary path.
-The draft pins the exact AgentField harness commit used for benchmarking;
-replace that pin with the released SDK before merging. The current Docker
-images do not bundle the unreleased Aforge binary.
 | `PR_AF_MODEL`               | Harness model (default `openrouter/moonshotai/kimi-k2.5`)      |
 | `PR_AF_MAX_COST_USD`        | Per-run cost ceiling in USD (default `2.0`)                    |
 | `PR_AF_MAX_DURATION_SECONDS`| Per-run wall-clock ceiling in seconds (default `3600`)         |
+
+Both Docker images include AForge and run `exec` by default. The Python node
+honors `PR_AF_AFORGE_BIN`; the maintained Go node honors
+`PR_AF_HARNESS_BIN`. OpenCode remains installed for a configuration-only
+rollback.
 | `AGENTFIELD_HARNESS_IDLE_SECONDS` | Harness no-output watchdog window in seconds (default `360`) — harness CLIs in JSON mode emit events only at completion boundaries, so long single completions look silent |
 | `PR_AF_WORKDIR`             | Where PR checkouts live (default `/workspaces`); each PR gets its own `<repo>-pr<N>` workspace |
 

--- a/README.md
+++ b/README.md
@@ -264,19 +264,24 @@ The key knobs (see `.env.example` for the full list):
 | `OPENROUTER_API_KEY`        | LLM provider key (OpenRouter) — required                       |
 | `GH_TOKEN`                  | GitHub token (`repo` scope) for reading PRs and posting reviews |
 | `PR_AF_PROVIDER`            | Harness provider (default `aforge`; use `opencode` to roll back) |
-| `AGENTFIELD_AFORGE_COMMAND` | AForge headless command (default `exec`; `do` is explicit)     |
+| `AGENTFIELD_AFORGE_COMMAND` | AForge headless command (default `exec`) — read by the Go node's SDK adapter; the pinned Python SDK always runs `exec` |
 | `PR_AF_AFORGE_BIN`          | Path to an aforge-v2 binary (default `aforge`)                 |
 | `PR_AF_HARNESS_BIN`         | Provider-agnostic executable override                          |
 | `PR_AF_MODEL`               | Harness model (default `openrouter/moonshotai/kimi-k2.5`)      |
 | `PR_AF_MAX_COST_USD`        | Per-run cost ceiling in USD (default `2.0`)                    |
 | `PR_AF_MAX_DURATION_SECONDS`| Per-run wall-clock ceiling in seconds (default `3600`)         |
-
-Both Docker images include AForge and run `exec` by default. The Python node
-honors `PR_AF_AFORGE_BIN`; the maintained Go node honors
-`PR_AF_HARNESS_BIN`. OpenCode remains installed for a configuration-only
-rollback.
 | `AGENTFIELD_HARNESS_IDLE_SECONDS` | Harness no-output watchdog window in seconds (default `360`) — harness CLIs in JSON mode emit events only at completion boundaries, so long single completions look silent |
 | `PR_AF_WORKDIR`             | Where PR checkouts live (default `/workspaces`); each PR gets its own `<repo>-pr<N>` workspace |
+
+Both Docker images ship the released AForge CLI (fetched and checksum-verified
+at build time from `https://agentfield.ai/downloads/aforge`) and run `exec` by
+default. The Python node resolves the binary from `PR_AF_AFORGE_BIN` (or
+`PR_AF_HARNESS_BIN`); the maintained Go node resolves it from
+`PR_AF_HARNESS_BIN`. OpenCode stays installed in both images, so
+`PR_AF_PROVIDER=opencode` is a configuration-only rollback — no rebuild.
+
+The image's AForge version is pinned by the `AFORGE_VERSION` build arg;
+`AFORGE_BASE_URL` points the fetch at a different host when needed.
 
 ## GitHub Actions Integration
 

--- a/README.md
+++ b/README.md
@@ -263,7 +263,16 @@ The key knobs (see `.env.example` for the full list):
 |-----------------------------|----------------------------------------------------------------|
 | `OPENROUTER_API_KEY`        | LLM provider key (OpenRouter) — required                       |
 | `GH_TOKEN`                  | GitHub token (`repo` scope) for reading PRs and posting reviews |
-| `PR_AF_PROVIDER`            | Harness provider (default `opencode`)                          |
+| `PR_AF_PROVIDER`            | Harness provider (default `opencode`; accepts `aforge`)        |
+| `PR_AF_AFORGE_BIN`          | Path to an aforge-v2 binary (default `aforge`)                 |
+| `PR_AF_HARNESS_BIN`         | Provider-agnostic executable override                          |
+
+For an unreleased aforge-v2 source benchmark, build `./cmd/aforge`, then run
+PR-AF with `PR_AF_PROVIDER=aforge` and either `PR_AF_AFORGE_BIN` (Python node)
+or `PR_AF_HARNESS_BIN` (maintained Go node) set to the absolute binary path.
+The draft pins the exact AgentField harness commit used for benchmarking;
+replace that pin with the released SDK before merging. The current Docker
+images do not bundle the unreleased Aforge binary.
 | `PR_AF_MODEL`               | Harness model (default `openrouter/moonshotai/kimi-k2.5`)      |
 | `PR_AF_MAX_COST_USD`        | Per-run cost ceiling in USD (default `2.0`)                    |
 | `PR_AF_MAX_DURATION_SECONDS`| Per-run wall-clock ceiling in seconds (default `3600`)         |

--- a/agentfield-package.yaml
+++ b/agentfield-package.yaml
@@ -50,7 +50,10 @@ user_environment:
       scope: global
     - name: PR_AF_PROVIDER
       description: Coding-agent harness provider (aforge | claude-code | codex | gemini | opencode)
-      default: opencode
+      default: aforge
+    - name: AGENTFIELD_AFORGE_COMMAND
+      description: AForge headless command
+      default: exec
     - name: PR_AF_AFORGE_BIN
       description: Optional path to the aforge-v2 binary (defaults to aforge on PATH)
     - name: PR_AF_MODEL

--- a/agentfield-package.yaml
+++ b/agentfield-package.yaml
@@ -52,7 +52,7 @@ user_environment:
       description: Coding-agent harness provider (aforge | claude-code | codex | gemini | opencode)
       default: aforge
     - name: AGENTFIELD_AFORGE_COMMAND
-      description: AForge headless command
+      description: AForge headless command (exec | do); the pinned Python SDK always runs exec
       default: exec
     - name: PR_AF_AFORGE_BIN
       description: Optional path to the aforge-v2 binary (defaults to aforge on PATH)

--- a/agentfield-package.yaml
+++ b/agentfield-package.yaml
@@ -49,8 +49,10 @@ user_environment:
       type: secret
       scope: global
     - name: PR_AF_PROVIDER
-      description: Coding-agent harness provider
+      description: Coding-agent harness provider (aforge | claude-code | codex | gemini | opencode)
       default: opencode
+    - name: PR_AF_AFORGE_BIN
+      description: Optional path to the aforge-v2 binary (defaults to aforge on PATH)
     - name: PR_AF_MODEL
       description: Model the harness uses
       default: openrouter/moonshotai/kimi-k2.5

--- a/agentfield-package.yaml
+++ b/agentfield-package.yaml
@@ -52,7 +52,7 @@ user_environment:
       description: Coding-agent harness provider (aforge | claude-code | codex | gemini | opencode)
       default: aforge
     - name: AGENTFIELD_AFORGE_COMMAND
-      description: AForge headless command (exec | do); the pinned Python SDK always runs exec
+      description: AForge headless command the SDK runs (exec | do); default exec on agentfield>=0.1.130
       default: exec
     - name: PR_AF_AFORGE_BIN
       description: Optional path to the aforge-v2 binary (defaults to aforge on PATH)

--- a/docker-compose.go.yml
+++ b/docker-compose.go.yml
@@ -40,7 +40,8 @@ services:
       - NODE_ID=pr-af-go
       - PORT=8007
       - AGENT_CALLBACK_URL=http://pr-af-go:8007
-      - PR_AF_PROVIDER=${PR_AF_PROVIDER:-opencode}
+      - PR_AF_PROVIDER=${PR_AF_PROVIDER:-aforge}
+      - AGENTFIELD_AFORGE_COMMAND=${AGENTFIELD_AFORGE_COMMAND:-exec}
       - PR_AF_MODEL=${PR_AF_MODEL:-openrouter/moonshotai/kimi-k2.5}
       # Optional generic executable override; leave unset for provider defaults.
       - PR_AF_HARNESS_BIN

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,8 @@ services:
       - AGENTFIELD_SERVER=http://agentfield:8080
       - AGENTFIELD_API_KEY=${AGENTFIELD_API_KEY:-}
       - AGENT_CALLBACK_URL=http://pr-af:8004
-      - PR_AF_PROVIDER=${PR_AF_PROVIDER:-opencode}
+      - PR_AF_PROVIDER=${PR_AF_PROVIDER:-aforge}
+      - AGENTFIELD_AFORGE_COMMAND=${AGENTFIELD_AFORGE_COMMAND:-exec}
       - PR_AF_MODEL=${PR_AF_MODEL:-openrouter/moonshotai/kimi-k2.5}
       - OPENROUTER_API_KEY=${OPENROUTER_API_KEY}
       - GH_TOKEN=${GH_TOKEN:-}

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -22,7 +22,7 @@
 FROM debian:bookworm-slim AS aforge
 
 ARG AFORGE_BASE_URL=https://agentfield.ai/downloads/aforge
-ARG AFORGE_VERSION=build-9b3ff482de3f
+ARG AFORGE_VERSION=v0.1.0
 ARG TARGETARCH
 
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -12,12 +12,42 @@
 # other dependency straight from the module proxy, cache-keyed on go.mod/go.sum.
 
 # ---------------------------------------------------------------------------
+# Stage 0 — aforge: fetch the released AForge CLI from the public download host
+# and verify it against the release checksums (which hash the DECOMPRESSED
+# binaries). Both ARGs are overridable so CI or a local mirror can serve the
+# assets from somewhere else:
+#
+#     docker build --build-arg AFORGE_BASE_URL=... --build-arg AFORGE_VERSION=... .
+# ---------------------------------------------------------------------------
+FROM debian:bookworm-slim AS aforge
+
+ARG AFORGE_BASE_URL=https://agentfield.ai/downloads/aforge
+ARG AFORGE_VERSION=build-9b3ff482de3f
+ARG TARGETARCH
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /out
+RUN set -eux; \
+    arch="${TARGETARCH:-$(dpkg --print-architecture)}"; \
+    curl -fsSL "${AFORGE_BASE_URL}/${AFORGE_VERSION}/aforge-linux-${arch}.gz" -o aforge.gz; \
+    gunzip -c aforge.gz > aforge; \
+    rm -f aforge.gz; \
+    curl -fsSL "${AFORGE_BASE_URL}/${AFORGE_VERSION}/checksums.txt" -o checksums.txt; \
+    grep " aforge-linux-${arch}$" checksums.txt | sed 's/  aforge-linux-.*/  aforge/' > aforge.sha256; \
+    test -s aforge.sha256; \
+    sha256sum -c aforge.sha256; \
+    rm -f checksums.txt aforge.sha256; \
+    chmod +x aforge
+
+
+# ---------------------------------------------------------------------------
 # Stage 1 — builder: fetch modules from the proxy, build the static binary.
 # Go 1.23 satisfies go.mod's `go 1.21` directive.
 # ---------------------------------------------------------------------------
-ARG AFORGE_IMAGE=ghcr.io/agent-field/aforge-v2:chat-v2-exec
-FROM ${AFORGE_IMAGE} AS aforge
-
 FROM golang:1.23-bookworm AS builder
 
 WORKDIR /src
@@ -71,7 +101,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /out/pr-af /usr/local/bin/pr-af
-COPY --from=aforge /aforge /usr/local/bin/aforge
+COPY --from=aforge /out/aforge /usr/local/bin/aforge
 COPY go/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -13,8 +13,11 @@
 
 # ---------------------------------------------------------------------------
 # Stage 1 — builder: fetch modules from the proxy, build the static binary.
-# golang 1.23 satisfies go.mod's `go 1.21` directive.
+# Go 1.23 satisfies go.mod's `go 1.21` directive.
 # ---------------------------------------------------------------------------
+ARG AFORGE_IMAGE=ghcr.io/agent-field/aforge-v2:chat-v2-exec
+FROM ${AFORGE_IMAGE} AS aforge
+
 FROM golang:1.23-bookworm AS builder
 
 WORKDIR /src
@@ -42,7 +45,8 @@ ARG OPENCODE_VERSION=1.17.15
 # PR_AF_HARNESS_BIN remains unset by default; set it only to override every
 # provider's executable path.
 ENV AGENTFIELD_SERVER=http://agentfield:8080 \
-    PR_AF_PROVIDER=opencode \
+    PR_AF_PROVIDER=aforge \
+    AGENTFIELD_AFORGE_COMMAND=exec \
     PR_AF_MODEL=openrouter/moonshotai/kimi-k2.5 \
     PORT=8007 \
     NODE_ID=pr-af \
@@ -67,6 +71,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /out/pr-af /usr/local/bin/pr-af
+COPY --from=aforge /aforge /usr/local/bin/aforge
 COPY go/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -106,6 +106,11 @@ COPY go/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 USER praf
+# Cwd must be writable by praf: the AgentField Go SDK creates its schema
+# output dir under the process cwd when a harness call carries no Cwd
+# (planning/coverage/dedup/worthiness/intake-fallback do), and `/` is
+# root-owned. /workspaces is praf-owned and is PR_AF_WORKDIR already.
+WORKDIR /workspaces
 
 EXPOSE 8007
 

--- a/go/README.md
+++ b/go/README.md
@@ -155,18 +155,15 @@ The node is configured entirely through the environment.
 | `AGENTFIELD_API_KEY`        | Control-plane API key (if the CP has auth enabled)             |
 | `NODE_ID`                   | Node ID (default `pr-af`)                                       |
 | `PORT`                      | Listen port (default `8007`)                                   |
-| `PR_AF_PROVIDER`            | Harness provider (default `opencode`; accepts `aforge`)        |
+| `PR_AF_PROVIDER`            | Harness provider (default `aforge`; use `opencode` to roll back) |
+| `AGENTFIELD_AFORGE_COMMAND` | AForge headless command (default `exec`; `do` is explicit)     |
 | `PR_AF_HARNESS_BIN`         | Provider executable override (set to the aforge-v2 binary)     |
-
-To benchmark unreleased aforge-v2 without changing PR-AF prompts, build
-`aforge-v2/cmd/aforge`, then set `PR_AF_PROVIDER=aforge` and
-`PR_AF_HARNESS_BIN=/absolute/path/to/aforge`. The draft pins the exact
-AgentField Go SDK commit used for benchmarking; replace that pin with the
-released SDK before merging. The current Docker image does not bundle the
-unreleased Aforge binary.
 | `PR_AF_MODEL`               | Harness model (default `openrouter/moonshotai/kimi-k2.5`)      |
 | `PR_AF_LABEL`               | Pull-request label that triggers a webhook review (default `pr-af`) |
 | `PR_AF_MAX_CONCURRENT_REVIEWERS` | Optional webhook review concurrency cap (minimum `1`)     |
+
+The image includes AForge and runs `exec` by default. OpenCode remains
+installed and can be selected with `PR_AF_PROVIDER=opencode` without rebuilding.
 | `PR_AF_MAX_REVIEW_DEPTH`    | Optional webhook sub-review depth cap (minimum `0`)            |
 | `PR_AF_MAX_COVERAGE_ITERATIONS` | Optional webhook coverage iteration cap (minimum `1`)      |
 | `PR_AF_HARNESS_BIN`         | Optional harness executable override for every provider; unset uses provider defaults |

--- a/go/README.md
+++ b/go/README.md
@@ -155,7 +155,15 @@ The node is configured entirely through the environment.
 | `AGENTFIELD_API_KEY`        | Control-plane API key (if the CP has auth enabled)             |
 | `NODE_ID`                   | Node ID (default `pr-af`)                                       |
 | `PORT`                      | Listen port (default `8007`)                                   |
-| `PR_AF_PROVIDER`            | Harness provider (default `opencode`)                          |
+| `PR_AF_PROVIDER`            | Harness provider (default `opencode`; accepts `aforge`)        |
+| `PR_AF_HARNESS_BIN`         | Provider executable override (set to the aforge-v2 binary)     |
+
+To benchmark unreleased aforge-v2 without changing PR-AF prompts, build
+`aforge-v2/cmd/aforge`, then set `PR_AF_PROVIDER=aforge` and
+`PR_AF_HARNESS_BIN=/absolute/path/to/aforge`. The draft pins the exact
+AgentField Go SDK commit used for benchmarking; replace that pin with the
+released SDK before merging. The current Docker image does not bundle the
+unreleased Aforge binary.
 | `PR_AF_MODEL`               | Harness model (default `openrouter/moonshotai/kimi-k2.5`)      |
 | `PR_AF_LABEL`               | Pull-request label that triggers a webhook review (default `pr-af`) |
 | `PR_AF_MAX_CONCURRENT_REVIEWERS` | Optional webhook review concurrency cap (minimum `1`)     |

--- a/go/README.md
+++ b/go/README.md
@@ -156,21 +156,22 @@ The node is configured entirely through the environment.
 | `NODE_ID`                   | Node ID (default `pr-af`)                                       |
 | `PORT`                      | Listen port (default `8007`)                                   |
 | `PR_AF_PROVIDER`            | Harness provider (default `aforge`; use `opencode` to roll back) |
-| `AGENTFIELD_AFORGE_COMMAND` | AForge headless command (default `exec`; `do` is explicit)     |
-| `PR_AF_HARNESS_BIN`         | Provider executable override (set to the aforge-v2 binary)     |
+| `AGENTFIELD_AFORGE_COMMAND` | AForge headless command — `exec` (default) or `do`             |
 | `PR_AF_MODEL`               | Harness model (default `openrouter/moonshotai/kimi-k2.5`)      |
 | `PR_AF_LABEL`               | Pull-request label that triggers a webhook review (default `pr-af`) |
 | `PR_AF_MAX_CONCURRENT_REVIEWERS` | Optional webhook review concurrency cap (minimum `1`)     |
-
-The image includes AForge and runs `exec` by default. OpenCode remains
-installed and can be selected with `PR_AF_PROVIDER=opencode` without rebuilding.
 | `PR_AF_MAX_REVIEW_DEPTH`    | Optional webhook sub-review depth cap (minimum `0`)            |
 | `PR_AF_MAX_COVERAGE_ITERATIONS` | Optional webhook coverage iteration cap (minimum `1`)      |
-| `PR_AF_HARNESS_BIN`         | Optional harness executable override for every provider; unset uses provider defaults |
+| `PR_AF_HARNESS_BIN`         | Optional harness executable override for every provider (point it at an `aforge` binary outside `PATH`); unset uses provider defaults |
 | `PR_AF_MAX_COST_USD`        | Per-run cost ceiling in USD (default `2.0`)                    |
 | `PR_AF_MAX_DURATION_SECONDS`| Per-run wall-clock ceiling in seconds (default `3600`)         |
 | `AGENTFIELD_HARNESS_IDLE_SECONDS` | Harness no-output watchdog window in seconds (default `360`) — harness CLIs in JSON mode emit events only at completion boundaries, so long single completions look silent |
 | `HAX_API_KEY`               | Optional — enables the HITL review-approval gate when set      |
+
+The image ships the released AForge CLI (fetched and checksum-verified at build
+time from `https://agentfield.ai/downloads/aforge`, pinned by the
+`AFORGE_VERSION` build arg) and runs `exec` by default. OpenCode remains
+installed and can be selected with `PR_AF_PROVIDER=opencode` without rebuilding.
 
 Note: the code default model is `minimax/minimax-m2.5`, while the Docker image /
 compose / manifest set `PR_AF_MODEL=openrouter/moonshotai/kimi-k2.5`. The env

--- a/go/agentfield-package.yaml
+++ b/go/agentfield-package.yaml
@@ -44,7 +44,7 @@ user_environment:
       description: harness provider (aforge | claude-code | codex | gemini | opencode)
       default: aforge
     - name: AGENTFIELD_AFORGE_COMMAND
-      description: AForge headless command
+      description: AForge headless command (exec | do)
       default: exec
     - name: PR_AF_MODEL
       description: harness model

--- a/go/agentfield-package.yaml
+++ b/go/agentfield-package.yaml
@@ -41,7 +41,7 @@ user_environment:
       type: secret
       scope: global
     - name: PR_AF_PROVIDER
-      description: harness provider
+      description: harness provider (aforge | claude-code | codex | gemini | opencode)
       default: opencode
     - name: PR_AF_MODEL
       description: harness model
@@ -56,7 +56,7 @@ user_environment:
     - name: PR_AF_MAX_COVERAGE_ITERATIONS
       description: optional coverage iteration cap for webhook-triggered reviews (minimum 1)
     - name: PR_AF_HARNESS_BIN
-      description: optional executable override for every harness provider (unset uses provider defaults)
+      description: optional executable override for every harness provider (set to an aforge-v2 binary with PR_AF_PROVIDER=aforge)
     - name: PR_AF_MAX_COST_USD
       description: per-run cost ceiling
       default: "2.0"

--- a/go/agentfield-package.yaml
+++ b/go/agentfield-package.yaml
@@ -42,7 +42,10 @@ user_environment:
       scope: global
     - name: PR_AF_PROVIDER
       description: harness provider (aforge | claude-code | codex | gemini | opencode)
-      default: opencode
+      default: aforge
+    - name: AGENTFIELD_AFORGE_COMMAND
+      description: AForge headless command
+      default: exec
     - name: PR_AF_MODEL
       description: harness model
       default: openrouter/moonshotai/kimi-k2.5

--- a/go/cmd/pr-af/main.go
+++ b/go/cmd/pr-af/main.go
@@ -13,7 +13,7 @@
 //	AGENT_CALLBACK_URL  base URL the CP uses to reach this node (else localhost)
 //	NODE_ID             node id (default pr-af)
 //	PORT                listen port (default 8007)
-//	PR_AF_PROVIDER      harness provider (default opencode; accepts aforge)
+//	PR_AF_PROVIDER      harness provider (default aforge; accepts opencode rollback)
 //	PR_AF_MODEL         harness model (env wins over the code default)
 //	PR_AF_HARNESS_BIN   optional executable override for every harness provider
 //	OPENROUTER_API_KEY  LLM key — required for the .ai() gates; AIConfig is only

--- a/go/cmd/pr-af/main.go
+++ b/go/cmd/pr-af/main.go
@@ -13,7 +13,7 @@
 //	AGENT_CALLBACK_URL  base URL the CP uses to reach this node (else localhost)
 //	NODE_ID             node id (default pr-af)
 //	PORT                listen port (default 8007)
-//	PR_AF_PROVIDER      harness provider (default opencode)
+//	PR_AF_PROVIDER      harness provider (default opencode; accepts aforge)
 //	PR_AF_MODEL         harness model (env wins over the code default)
 //	PR_AF_HARNESS_BIN   optional executable override for every harness provider
 //	OPENROUTER_API_KEY  LLM key — required for the .ai() gates; AIConfig is only

--- a/go/go.mod
+++ b/go/go.mod
@@ -5,7 +5,7 @@ module github.com/Agent-Field/pr-af/go
 go 1.21
 
 require (
-	github.com/Agent-Field/agentfield/sdk/go v0.1.127-rc.5.0.20260815031530-bfd34426d1bd
+	github.com/Agent-Field/agentfield/sdk/go v0.1.130
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/invopop/jsonschema v0.13.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1

--- a/go/go.mod
+++ b/go/go.mod
@@ -5,7 +5,7 @@ module github.com/Agent-Field/pr-af/go
 go 1.21
 
 require (
-	github.com/Agent-Field/agentfield/sdk/go v0.1.127-rc.5.0.20260810165835-72f3d00baf58
+	github.com/Agent-Field/agentfield/sdk/go v0.1.127-rc.5.0.20260815031530-bfd34426d1bd
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/invopop/jsonschema v0.13.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1

--- a/go/go.mod
+++ b/go/go.mod
@@ -5,7 +5,7 @@ module github.com/Agent-Field/pr-af/go
 go 1.21
 
 require (
-	github.com/Agent-Field/agentfield/sdk/go v0.0.0-20260714191100-2cc5fe2adcf4
+	github.com/Agent-Field/agentfield/sdk/go v0.1.127-rc.5.0.20260810165835-72f3d00baf58
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/invopop/jsonschema v0.13.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1

--- a/go/go.sum
+++ b/go/go.sum
@@ -1,5 +1,3 @@
-github.com/Agent-Field/agentfield/sdk/go v0.1.127-rc.5.0.20260810165835-72f3d00baf58 h1:B9ITli2PwuEG+lv7md3CuFAiCnTcuhNIJ6hjNQVTQqQ=
-github.com/Agent-Field/agentfield/sdk/go v0.1.127-rc.5.0.20260810165835-72f3d00baf58/go.mod h1:08VZk14uw4GJH6a34psHkuLu+DcRr197Zi0IGmLlfrM=
 github.com/Agent-Field/agentfield/sdk/go v0.1.127-rc.5.0.20260815031530-bfd34426d1bd h1:nL0ST2D2Ds7CQhjcs7pbFQdJ/8z+oUXYF9bpQURjx6k=
 github.com/Agent-Field/agentfield/sdk/go v0.1.127-rc.5.0.20260815031530-bfd34426d1bd/go.mod h1:08VZk14uw4GJH6a34psHkuLu+DcRr197Zi0IGmLlfrM=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=

--- a/go/go.sum
+++ b/go/go.sum
@@ -1,5 +1,7 @@
 github.com/Agent-Field/agentfield/sdk/go v0.1.127-rc.5.0.20260810165835-72f3d00baf58 h1:B9ITli2PwuEG+lv7md3CuFAiCnTcuhNIJ6hjNQVTQqQ=
 github.com/Agent-Field/agentfield/sdk/go v0.1.127-rc.5.0.20260810165835-72f3d00baf58/go.mod h1:08VZk14uw4GJH6a34psHkuLu+DcRr197Zi0IGmLlfrM=
+github.com/Agent-Field/agentfield/sdk/go v0.1.127-rc.5.0.20260815031530-bfd34426d1bd h1:nL0ST2D2Ds7CQhjcs7pbFQdJ/8z+oUXYF9bpQURjx6k=
+github.com/Agent-Field/agentfield/sdk/go v0.1.127-rc.5.0.20260815031530-bfd34426d1bd/go.mod h1:08VZk14uw4GJH6a34psHkuLu+DcRr197Zi0IGmLlfrM=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=

--- a/go/go.sum
+++ b/go/go.sum
@@ -1,5 +1,5 @@
-github.com/Agent-Field/agentfield/sdk/go v0.1.127-rc.5.0.20260815031530-bfd34426d1bd h1:nL0ST2D2Ds7CQhjcs7pbFQdJ/8z+oUXYF9bpQURjx6k=
-github.com/Agent-Field/agentfield/sdk/go v0.1.127-rc.5.0.20260815031530-bfd34426d1bd/go.mod h1:08VZk14uw4GJH6a34psHkuLu+DcRr197Zi0IGmLlfrM=
+github.com/Agent-Field/agentfield/sdk/go v0.1.130 h1:k6ATecElqx54AUGzmFnbJy/BrFY+2UhPV7VM3X8ByTw=
+github.com/Agent-Field/agentfield/sdk/go v0.1.130/go.mod h1:08VZk14uw4GJH6a34psHkuLu+DcRr197Zi0IGmLlfrM=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=

--- a/go/go.sum
+++ b/go/go.sum
@@ -1,5 +1,5 @@
-github.com/Agent-Field/agentfield/sdk/go v0.0.0-20260714191100-2cc5fe2adcf4 h1:B3uCMLZSa2rsRDRGuecBIXCgkYqBuScSK4CXKPDaCgk=
-github.com/Agent-Field/agentfield/sdk/go v0.0.0-20260714191100-2cc5fe2adcf4/go.mod h1:08VZk14uw4GJH6a34psHkuLu+DcRr197Zi0IGmLlfrM=
+github.com/Agent-Field/agentfield/sdk/go v0.1.127-rc.5.0.20260810165835-72f3d00baf58 h1:B9ITli2PwuEG+lv7md3CuFAiCnTcuhNIJ6hjNQVTQqQ=
+github.com/Agent-Field/agentfield/sdk/go v0.1.127-rc.5.0.20260810165835-72f3d00baf58/go.mod h1:08VZk14uw4GJH6a34psHkuLu+DcRr197Zi0IGmLlfrM=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=

--- a/go/internal/config/ai.go
+++ b/go/internal/config/ai.go
@@ -53,7 +53,7 @@ func AIConfigFromEnv() (AIIntegrationConfig, error) {
 		return AIIntegrationConfig{}, err
 	}
 	return AIIntegrationConfig{
-		Provider:     strEnv("PR_AF_PROVIDER", "opencode"),
+		Provider:     strEnv("PR_AF_PROVIDER", "aforge"),
 		HarnessModel: strEnv("PR_AF_MODEL", "minimax/minimax-m2.5"),
 		// AI_MODEL falls back to PR_AF_MODEL, then to the code default.
 		AIModel:               strEnv("PR_AF_AI_MODEL", strEnv("PR_AF_MODEL", "minimax/minimax-m2.5")),
@@ -90,6 +90,7 @@ func (c AIIntegrationConfig) ProviderEnv() map[string]string {
 	}
 	_ = os.MkdirAll(xdg, 0o755)
 	env["XDG_DATA_HOME"] = xdg
+	env["AGENTFIELD_AFORGE_COMMAND"] = strEnv("AGENTFIELD_AFORGE_COMMAND", "exec")
 	return env
 }
 

--- a/go/internal/config/config_test.go
+++ b/go/internal/config/config_test.go
@@ -134,8 +134,8 @@ func TestResolveBudgetCapsCascade(t *testing.T) {
 func TestAIConfigFromEnvDefaults(t *testing.T) {
 	clearConfigEnv(t)
 	c := mustAIConfig(t)
-	if c.Provider != "opencode" {
-		t.Errorf("Provider = %q, want opencode", c.Provider)
+	if c.Provider != "aforge" {
+		t.Errorf("Provider = %q, want aforge", c.Provider)
 	}
 	// The CODE default is minimax — NOT the manifest's kimi default. env wins,
 	// but with no env this must be minimax (design §B.6).
@@ -237,6 +237,9 @@ func TestProviderEnv(t *testing.T) {
 	}
 	if env["XDG_DATA_HOME"] != xdg {
 		t.Errorf("XDG_DATA_HOME = %q, want %q", env["XDG_DATA_HOME"], xdg)
+	}
+	if env["AGENTFIELD_AFORGE_COMMAND"] != "exec" {
+		t.Errorf("AGENTFIELD_AFORGE_COMMAND = %q, want exec", env["AGENTFIELD_AFORGE_COMMAND"])
 	}
 
 	// With XDG_DATA_HOME unset, ProviderEnv falls back to a tmp dir and creates

--- a/go/internal/harnessx/run.go
+++ b/go/internal/harnessx/run.go
@@ -80,7 +80,7 @@ func seedDefaults[T any]() T {
 // router.harness (system_prompt, schema, model, provider, tools, cwd, max_turns,
 // permission_mode).
 type RoleOptions struct {
-	// Provider is the harness ADAPTER string, e.g. "aforge" or "opencode" (PR-AF's default),
+	// Provider is the harness ADAPTER string, e.g. "aforge" (PR-AF's default) or "opencode",
 	// "claude-code", "codex".
 	Provider string
 

--- a/go/internal/harnessx/run.go
+++ b/go/internal/harnessx/run.go
@@ -80,7 +80,7 @@ func seedDefaults[T any]() T {
 // router.harness (system_prompt, schema, model, provider, tools, cwd, max_turns,
 // permission_mode).
 type RoleOptions struct {
-	// Provider is the harness ADAPTER string, e.g. "opencode" (PR-AF's default),
+	// Provider is the harness ADAPTER string, e.g. "aforge" or "opencode" (PR-AF's default),
 	// "claude-code", "codex".
 	Provider string
 

--- a/go/internal/node/node.go
+++ b/go/internal/node/node.go
@@ -139,7 +139,7 @@ func resolvedHarnessBin(c config.AIIntegrationConfig) string {
 //   - PORT               default "8007" -> ListenAddress ":8007".
 //   - AGENT_CALLBACK_URL -> Config.PublicURL — the base URL the CP uses to reach
 //     this node; unset falls back to the SDK's http://localhost:<port>.
-//   - HarnessConfig / AIConfig — the harness (opencode) + LLM credentials the
+//   - HarnessConfig / AIConfig — the selected harness + LLM credentials the
 //     reasoners rely on. Every reasoner calls the harness with only Cwd set, so
 //     the agent's default HarnessConfig Provider/Model must be present, and the
 //     two .ai() gates (intake/coverage) need AIConfig. Mirrors app.py's

--- a/go/internal/node/node_test.go
+++ b/go/internal/node/node_test.go
@@ -16,6 +16,8 @@ func TestHarnessConfigProviderAwareBinary(t *testing.T) {
 	}{
 		{"codex uses SDK default", config.AIIntegrationConfig{Provider: "codex", OpencodeBin: "C:/bin/opencode-custom"}, ""},
 		{"opencode uses configured binary", config.AIIntegrationConfig{Provider: "opencode", OpencodeBin: "C:/bin/opencode-custom"}, "C:/bin/opencode-custom"},
+		{"aforge uses SDK default", config.AIIntegrationConfig{Provider: "aforge", OpencodeBin: "C:/bin/opencode-custom"}, ""},
+		{"generic override selects aforge", config.AIIntegrationConfig{Provider: "aforge", HarnessBin: "C:/bin/aforge-custom"}, "C:/bin/aforge-custom"},
 		{"generic override wins", config.AIIntegrationConfig{Provider: "codex", OpencodeBin: "C:/bin/opencode-custom", HarnessBin: "C:/bin/provider-custom"}, "C:/bin/provider-custom"},
 		{"generic override wins for opencode", config.AIIntegrationConfig{Provider: "opencode", OpencodeBin: "C:/bin/opencode-custom", HarnessBin: "C:/bin/provider-custom"}, "C:/bin/provider-custom"},
 	}

--- a/go/internal/node/node_test.go
+++ b/go/internal/node/node_test.go
@@ -45,7 +45,11 @@ func TestHarnessConfigPreservesExistingFields(t *testing.T) {
 	if got.Provider != conf.Provider || got.Model != conf.HarnessModel || got.MaxTurns != conf.MaxTurns || got.PermissionMode != "auto" || got.BinPath != conf.OpencodeBin {
 		t.Errorf("harnessConfig fields = %+v", got)
 	}
-	if want := map[string]string{"OPENAI_API_KEY": "openai-key", "XDG_DATA_HOME": xdg}; !reflect.DeepEqual(got.Env, want) {
+	if want := map[string]string{
+		"OPENAI_API_KEY":            "openai-key",
+		"XDG_DATA_HOME":             xdg,
+		"AGENTFIELD_AFORGE_COMMAND": "exec",
+	}; !reflect.DeepEqual(got.Env, want) {
 		t.Errorf("Env = %#v, want %#v", got.Env, want)
 	}
 }

--- a/go/test/functional/compose.functional.yml
+++ b/go/test/functional/compose.functional.yml
@@ -49,7 +49,8 @@ services:
       - NODE_ID=pr-af
       - PORT=8007
       - AGENT_CALLBACK_URL=http://pr-af:8007
-      - PR_AF_PROVIDER=${PR_AF_PROVIDER:-opencode}
+      - PR_AF_PROVIDER=${PR_AF_PROVIDER:-aforge}
+      - AGENTFIELD_AFORGE_COMMAND=${AGENTFIELD_AFORGE_COMMAND:-exec}
       - PR_AF_MODEL=${PR_AF_MODEL:-openrouter/moonshotai/kimi-k2.5}
       - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
       - GH_TOKEN=${GH_TOKEN:-}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 requires-python = ">=3.11"
 authors = [{ name = "AgentField", email = "hello@agentfield.dev" }]
 dependencies = [
-    "agentfield>=0.1.129",
+    "agentfield>=0.1.130",
     "hax-sdk>=0.2.4",
     "pydantic>=2.0",
     "httpx>=0.27",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 requires-python = ">=3.11"
 authors = [{ name = "AgentField", email = "hello@agentfield.dev" }]
 dependencies = [
-    "agentfield>=0.1.84",
+    "agentfield @ git+https://github.com/Agent-Field/agentfield.git@72f3d00baf58efc4fec3f7ee16e69c7cb8f99ff9#subdirectory=sdk/python",
     "hax-sdk>=0.2.4",
     "pydantic>=2.0",
     "httpx>=0.27",
@@ -35,6 +35,9 @@ pr-af = "pr_af.app:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/pr_af"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.ruff]
 target-version = "py311"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 requires-python = ">=3.11"
 authors = [{ name = "AgentField", email = "hello@agentfield.dev" }]
 dependencies = [
-    "agentfield @ git+https://github.com/Agent-Field/agentfield.git@72f3d00baf58efc4fec3f7ee16e69c7cb8f99ff9#subdirectory=sdk/python",
+    "agentfield @ git+https://github.com/Agent-Field/agentfield.git@bfd34426d1bdec3cbbfa946682a22ef0a1b91503#subdirectory=sdk/python",
     "hax-sdk>=0.2.4",
     "pydantic>=2.0",
     "httpx>=0.27",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 requires-python = ">=3.11"
 authors = [{ name = "AgentField", email = "hello@agentfield.dev" }]
 dependencies = [
-    "agentfield @ git+https://github.com/Agent-Field/agentfield.git@bfd34426d1bdec3cbbfa946682a22ef0a1b91503#subdirectory=sdk/python",
+    "agentfield>=0.1.129",
     "hax-sdk>=0.2.4",
     "pydantic>=2.0",
     "httpx>=0.27",
@@ -35,9 +35,6 @@ pr-af = "pr_af.app:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/pr_af"]
-
-[tool.hatch.metadata]
-allow-direct-references = true
 
 [tool.ruff]
 target-version = "py311"

--- a/src/pr_af/app.py
+++ b/src/pr_af/app.py
@@ -43,7 +43,8 @@ app = Agent(
         model=_ai_config.harness_model,
         max_turns=_ai_config.max_turns,
         env=_ai_config.provider_env(),
-        opencode_bin=_ai_config.opencode_bin,
+        opencode_bin=_ai_config.harness_bin or _ai_config.opencode_bin,
+        aforge_bin=_ai_config.harness_bin or _ai_config.aforge_bin,
         permission_mode="auto",
     ),
     ai_config=AIConfig(

--- a/src/pr_af/config.py
+++ b/src/pr_af/config.py
@@ -313,7 +313,7 @@ class ReviewConfig(BaseModel):
 
 
 class AIIntegrationConfig(BaseModel):
-    provider: str = Field(default_factory=lambda: os.getenv("PR_AF_PROVIDER", "opencode"))
+    provider: str = Field(default_factory=lambda: os.getenv("PR_AF_PROVIDER", "aforge"))
     harness_model: str = Field(
         default_factory=lambda: os.getenv("PR_AF_MODEL", "minimax/minimax-m2.5")
     )
@@ -352,6 +352,7 @@ class AIIntegrationConfig(BaseModel):
             "GH_TOKEN",
         )
         env: dict[str, str] = {key: value for key in env_keys if (value := os.getenv(key))}
+        env["AGENTFIELD_AFORGE_COMMAND"] = os.getenv("AGENTFIELD_AFORGE_COMMAND", "exec")
         xdg = os.getenv("XDG_DATA_HOME") or os.path.join(tempfile.gettempdir(), "opencode-shared-data")
         os.makedirs(xdg, exist_ok=True)
         env["XDG_DATA_HOME"] = xdg

--- a/src/pr_af/config.py
+++ b/src/pr_af/config.py
@@ -330,6 +330,13 @@ class AIIntegrationConfig(BaseModel):
     )
     max_backoff_seconds: float = Field(default_factory=lambda: float(os.getenv("PR_AF_AI_MAX_BACKOFF_SECONDS", "8.0")))
     opencode_bin: str = Field(default_factory=lambda: os.getenv("PR_AF_OPENCODE_BIN", "opencode"))
+    aforge_bin: str = Field(
+        default_factory=lambda: os.getenv(
+            "PR_AF_AFORGE_BIN",
+            os.getenv("AFORGE_BIN", "aforge"),
+        )
+    )
+    harness_bin: str = Field(default_factory=lambda: os.getenv("PR_AF_HARNESS_BIN", ""))
     opencode_server: str | None = Field(default_factory=lambda: os.getenv("PR_AF_OPENCODE_SERVER"))
 
     @classmethod

--- a/tests/test_aforge_config.py
+++ b/tests/test_aforge_config.py
@@ -20,3 +20,19 @@ def test_generic_harness_binary_is_available_to_all_providers(monkeypatch) -> No
     config = AIIntegrationConfig.from_env()
 
     assert config.harness_bin == "/opt/harness"
+
+
+def test_aforge_exec_is_the_default(monkeypatch) -> None:
+    monkeypatch.delenv("PR_AF_PROVIDER", raising=False)
+    monkeypatch.delenv("AGENTFIELD_AFORGE_COMMAND", raising=False)
+
+    config = AIIntegrationConfig.from_env()
+
+    assert config.provider == "aforge"
+    assert config.provider_env()["AGENTFIELD_AFORGE_COMMAND"] == "exec"
+
+
+def test_opencode_remains_an_explicit_rollback(monkeypatch) -> None:
+    monkeypatch.setenv("PR_AF_PROVIDER", "opencode")
+
+    assert AIIntegrationConfig.from_env().provider == "opencode"

--- a/tests/test_aforge_config.py
+++ b/tests/test_aforge_config.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from pr_af.config import AIIntegrationConfig
+
+
+def test_aforge_provider_and_binary_overrides(monkeypatch) -> None:
+    monkeypatch.setenv("PR_AF_PROVIDER", "aforge")
+    monkeypatch.setenv("PR_AF_AFORGE_BIN", "/opt/aforge")
+
+    config = AIIntegrationConfig.from_env()
+
+    assert config.provider == "aforge"
+    assert config.aforge_bin == "/opt/aforge"
+    assert config.harness_bin == ""
+
+
+def test_generic_harness_binary_is_available_to_all_providers(monkeypatch) -> None:
+    monkeypatch.setenv("PR_AF_HARNESS_BIN", "/opt/harness")
+
+    config = AIIntegrationConfig.from_env()
+
+    assert config.harness_bin == "/opt/harness"


### PR DESCRIPTION
> ## Status update — agentfield v0.1.130 is released; this PR is ready
> Everything below the line was written against the 0.1.129 / rc pins and is kept for history. What is true on the current head:
> - **Pins bumped**: Python `agentfield>=0.1.130` (pyproject + Dockerfile); Go `sdk/go v0.1.130` (`go/go.mod`/`go.sum`, resolved via the module proxy; `go version -m` on the image binary shows `sdk/go v0.1.130`).
> - **"Known-inert knobs" are no longer inert**: 0.1.130 reads `AGENTFIELD_AFORGE_COMMAND` (`exec` default, `do` opt-in), honours `AFORGE_BIN`, and passes `--timeout`/`--turns` to aforge. Manifest wording updated.
> - **Extra fix (pre-existing, found by the live run):** `go/Dockerfile` runtime stage had no `WORKDIR`, so the non-root `praf` process ran with cwd `/` and every cwd-less harness call (planning, coverage, compound dedup, worthiness, intake fallback) failed with `mkdir ./.agentfield-out-…: permission denied` — after the review had spent its LLM budget. Added `WORKDIR /workspaces`. Not caused by the aforge switch (identical SDK logic on the previous pin), but the maintained Go node could not finish a review without it.
> - **Live verification (real OpenRouter key, default provider, nothing overridden):** both images built with default args from `agentfield.ai` + PyPI (`aforge v0.1.0`, `agentfield 0.1.130`); both nodes registered on a fresh `agentfield/control-plane:latest` (= v0.1.130) and completed a `review` of a small public PR with `dry_run: true` (0 comments posted): Python 5 findings / 17.6 min, Go 8 findings / 21.1 min; argv captured live in both containers: `aforge exec --json -w /workspaces/<repo> --timeout 1795 --turns 50 --context-fill 60 --completion-reserve 65536 --model … --plan-model …`. Go/Python config tests confirm `aforge` is the code default and `PR_AF_PROVIDER=claude-code` flips it. Go: build/vet/test/gofmt clean; Python: 107 passed, ruff clean.
> - Un-draft preconditions met (site live, 0.1.130 on PyPI, sdk/go tag present).
>
> ---
>
## Summary

Make AForge `exec` the default harness in both the Python and the maintained Go
PR-AF nodes, ship the released AForge CLI in both images, and keep OpenCode
installed as a configuration-only rollback.

This revision replaces the two blockers that made the branch unbuildable:

- **The images no longer pull a private GHCR package.** Both Dockerfiles used
  `FROM ghcr.io/agent-field/aforge-v2:chat-v2-exec AS aforge` +
  `COPY --from=aforge /aforge`. That package is private, so `docker build`
  returned a 403 for anyone without registry access — including the
  `docker-build` CI job. Both now use a fetch stage that downloads the
  published, gzipped release asset over HTTPS and verifies it against the
  release `checksums.txt` before installing it.
- **The Python node is pinned to a PyPI release, not a git commit.** The branch
  pinned `agentfield` to a commit on the adapter branch (and turned on
  hatchling's `allow-direct-references` to make that legal). The AForge provider
  has shipped on PyPI since 0.1.127, so `agentfield>=0.1.129` is enough.

## What changed

**Docker (`Dockerfile`, `go/Dockerfile`)**

```dockerfile
FROM debian:bookworm-slim AS aforge
ARG AFORGE_BASE_URL=https://agentfield.ai/downloads/aforge
ARG AFORGE_VERSION=v0.1.0
ARG TARGETARCH
# curl the .gz, gunzip to /out/aforge, sha256-verify the DECOMPRESSED binary
# against checksums.txt, chmod +x
...
COPY --from=aforge /out/aforge /usr/local/bin/aforge
```

Both `ARG`s are overridable, so CI or a local mirror can serve the assets from
somewhere else without editing the Dockerfile. `checksums.txt` is copied verbatim
from the aforge-v2 release and hashes the *uncompressed* binaries, so the
verification runs after `gunzip`. Both runtime stages already install
`ca-certificates`, which AForge needs to reach the model provider over HTTPS.

**Python SDK pin** — `pyproject.toml` and the builder stage of `Dockerfile` now
use `agentfield>=0.1.129`; the `[tool.hatch.metadata] allow-direct-references`
escape hatch (added only for the git dependency) is gone.

**Go SDK pin** — `go/go.mod` keeps
`github.com/Agent-Field/agentfield/sdk/go v0.1.127-rc.5.0.20260815031530-bfd34426d1bd`,
which resolves through proxy.golang.org and is the only pin that carries the Go
AForge adapter today. `go mod tidy` removed the superseded
`v0.1.127-rc.5.0.20260810165835-72f3d00baf58` hashes the branch had left in
`go/go.sum`.

**Docs** — the branch dropped a prose paragraph into the middle of the env-var
table in `README.md` and `go/README.md`, which truncates the rendered table and
leaves the remaining rows as literal pipe text. Both tables are repaired (prose
moved below), and the duplicate `PR_AF_HARNESS_BIN` row the branch added to
`go/README.md` is dropped.

## Known-inert knobs until agentfield#905 releases

The Python SDK on PyPI (0.1.129) and the pinned Go SDK do **not** behave
identically yet:

| Knob | Go node (pinned pseudo-version) | Python node (agentfield 0.1.129) |
|------|--------------------------------|----------------------------------|
| `AGENTFIELD_AFORGE_COMMAND` | honored (`exec` \| `do`) | **inert** — the adapter always runs `aforge exec` |
| `AFORGE_BIN` (SDK-level) | honored | **inert** at SDK level; PR-AF's own `PR_AF_AFORGE_BIN` / `AFORGE_BIN` still work, because `src/pr_af/config.py` reads them and passes `HarnessConfig.aforge_bin` |
| `--timeout` passed to `aforge exec` | passed | **not passed** — AForge's own 15-minute wall applies |

The docs in this PR state that scope rather than implying the Python node reads
those vars. When agentfield#905 ships as a tagged release, bump these exact
lines:

- `pyproject.toml:14` — `"agentfield>=0.1.129",` → the #905 release floor
- `Dockerfile:50` — `"agentfield>=0.1.129" \` → the same floor (the constraint
  string itself must change, or Docker's layer cache keeps reinstalling 0.1.129)
- `go/go.mod:8` — the sdk/go pseudo-version → the tagged release, then
  `go mod tidy`

## Validation contract

Observable behaviours this change must exhibit:

1. `docker build .` succeeds without any GHCR credentials.
2. The `aforge` binary inside both images is byte-identical to the published
   release asset for the target architecture.
3. A corrupted or mismatched `checksums.txt` **fails** the build rather than
   shipping an unverified binary.
4. `aforge --help` runs inside both images.
5. `aforge exec --json -w <dir>` inside the image returns exit 0 and a JSON
   envelope for a real prompt, given `OPENROUTER_API_KEY`.
6. With no `PR_AF_PROVIDER` set, both nodes resolve the harness provider to
   `aforge` and point it at the bundled binary.
7. `PR_AF_PROVIDER=opencode` still resolves to the OpenCode provider, with the
   OpenCode CLI still present in both images (rollback without a rebuild).
8. Repo gates stay green: ruff, pytest, `go build` / `vet` / `test` / `gofmt`.

## How it was verified

Locally, against a mirror of the published layout (the assets are not on
agentfield.ai yet — see below), overriding only `AFORGE_BASE_URL`:

- **(1)** `docker build -t pr-af-aforge-test .` and
  `docker build -f go/Dockerfile -t pr-af-go-aforge-test .` — both exit 0.
- **(2)** `sha256sum /usr/local/bin/aforge` in **both** images →
  `61217a18135f392d50c337d971fa5b228f436f8df144800b37fbb340020c79f5`, matching
  the `aforge-linux-amd64` line in the release `checksums.txt`.
- **(3)** Negative test: rebuilt `--no-cache --target aforge` against a mirror
  whose `checksums.txt` had the amd64 hash zeroed →
  `sha256sum: WARNING: 1 computed checksum did NOT match` / `aforge: FAILED`,
  build exit 1. The verification is not vacuous.
- **(4)** `docker run --rm --entrypoint aforge <img> --help` → exit 0 in both
  images.
- **(5)** `echo "Reply with exactly OK" | aforge exec --json -w /tmp/w --timeout 120 --budget 20000 --turns 3`
  inside both images →
  `{"text":"OK","stop":"done","usage":{...},"artifacts":[],"turns":1,...}`,
  exit 0.
- **(6)/(7)** Resolution probes run *inside* the containers:
  - Python image: `pr_af.config.AIIntegrationConfig.from_env()` →
    `provider = aforge`; `agentfield.harness.providers._factory.build_provider`
    → `AforgeProvider`, bin `aforge -> /usr/local/bin/aforge`;
    `opencode -> /home/praf/.opencode/bin/opencode` still present. With
    `PR_AF_PROVIDER=opencode` → `OpenCodeProvider`.
  - Go image: `config.AIConfigFromEnv()` + `node.BuildAgent(...)` +
    `harness.BuildProvider` → `resolved provider = aforge`,
    `*harness.AforgeProvider`, bin `aforge -> /usr/local/bin/aforge`;
    with `PR_AF_PROVIDER=opencode` → `*harness.OpenCodeProvider`.
- **(8)** `ruff check src/ scripts/` → all checks passed. `pytest` → 107 passed.
  In `go/`: `go build ./...`, `go vet ./...`, `go test ./...` (all packages ok),
  `gofmt -l .` empty.

## CI expectation — `docker-build` stays red for now

`https://agentfield.ai/downloads/aforge/v0.1.0/` currently returns **404**. The
host itself is live and already serves the older `build-<sha>` coordinate — what
is missing is the v0.1.0 publish. Until it lands, the default `AFORGE_BASE_URL`
has nothing to fetch and the `docker-build` job will fail on the aforge stage.
`lint` and `go` should be green.

## Stays in draft until

1. `https://agentfield.ai/downloads/aforge/<version>/` serves
   `aforge-linux-{amd64,arm64}.gz` + `checksums.txt`, and `docker-build` goes
   green on a re-run with no build args.
2. agentfield#905 ships a tagged release, and the three pin lines listed above
   are bumped so `AGENTFIELD_AFORGE_COMMAND`, SDK-level `AFORGE_BIN` and the
   `--timeout` pass-through stop being inert on the Python node.

Both are external; nothing else in this PR is waiting on review feedback.

## Follow-ups (not in this PR)

- Consider fetching AForge in the `af install` (non-Docker) path too — today only
  the images bundle it, so a bare-metal `af run` needs `aforge` on `PATH`.
- Once #905 lands, add a functional test that asserts the Python node passes
  `--timeout` derived from `PR_AF_MAX_DURATION_SECONDS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


