### PR TITLE
Make GH_TOKEN optional in the Go node manifest

### DIFF
--- a/go/agentfield-package.yaml
+++ b/go/agentfield-package.yaml
@@ -28,11 +28,16 @@ user_environment:
       description: LLM provider key (OpenRouter)
       type: secret
       scope: global
+  optional:
+    # Optional, not required: every use is lazy and degrades cleanly without it
+    # (github.NewClient falls back to unauthenticated API calls, clones only
+    # inject the token when set) — public repos review fine anonymously. The
+    # token is needed for private repos, posting reviews back to GitHub, and
+    # unthrottled API rate limits.
     - name: GH_TOKEN
-      description: GitHub token (repo scope)
+      description: GitHub token (repo scope) — needed only for private repos and posting reviews
       type: secret
       scope: global
-  optional:
     - name: AGENTFIELD_SERVER
       description: Control-plane URL
       default: http://localhost:8080

--- a/go/cmd/pr-af/main.go
+++ b/go/cmd/pr-af/main.go
@@ -18,7 +18,9 @@
 //	PR_AF_HARNESS_BIN   optional executable override for every harness provider
 //	OPENROUTER_API_KEY  LLM key — required for the .ai() gates; AIConfig is only
 //	                    attached when set (SDK rejects an empty key)
-//	GH_TOKEN            GitHub token for FetchPR/clone/PostReview
+//	GH_TOKEN            GitHub token for FetchPR/clone/PostReview (optional —
+//	                    public repos review anonymously; needed for private
+//	                    repos and posting reviews)
 //	GITHUB_WEBHOOK_SECRET  HMAC secret for /webhook/github (skip verify if unset)
 //	PR_AF_BOT_MENTION   webhook trigger mention (default @pr-af)
 package main


### PR DESCRIPTION
## Summary

Moves `GH_TOKEN` from `user_environment.required` to `optional` in the Go node's `agentfield-package.yaml`, and notes the optionality in the `main.go` env-var doc header.

The code already treats the token as optional at every use site — nothing gates at startup:

- `github.NewClient` falls back to unauthenticated API calls when the token is empty (`go/internal/github/client.go`)
- repo clones inject the token into the URL only when it is set (`go/internal/orch/resolve.go`)
- `ProviderEnv` forwards it to the harness only if present (`go/internal/config/ai.go`)
- the e2e and functional harnesses already run with `GH_TOKEN` unset

Public repos review fine anonymously; the token is needed only for private repos, posting reviews back to GitHub, and unthrottled API rate limits — the new description says so.

Requiring it meant a fresh AgentField desktop install (which now bundles pr-af) gated the node behind a "Needs keys" prompt for a credential many reviews never touch.

The legacy Python root manifest is deliberately untouched: its comment says the Python node genuinely needs GitHub write access mid-run.

## Testing

- `go build ./...` and `go vet ./cmd/pr-af` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)